### PR TITLE
Save sync.Map by value, not by reference

### DIFF
--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -17,7 +17,7 @@ type GeneratorInterceptor struct {
 	size        uint16
 	skipLastN   uint16
 	interval    time.Duration
-	receiveLogs *sync.Map
+	receiveLogs sync.Map
 	m           sync.Mutex
 	wg          sync.WaitGroup
 	close       chan struct{}
@@ -27,12 +27,11 @@ type GeneratorInterceptor struct {
 // NewGeneratorInterceptor returns a new GeneratorInterceptor interceptor
 func NewGeneratorInterceptor(opts ...GeneratorOption) (*GeneratorInterceptor, error) {
 	r := &GeneratorInterceptor{
-		size:        8192,
-		skipLastN:   0,
-		interval:    time.Millisecond * 100,
-		receiveLogs: &sync.Map{},
-		close:       make(chan struct{}),
-		log:         logging.NewDefaultLoggerFactory().NewLogger("nack_generator"),
+		size:      8192,
+		skipLastN: 0,
+		interval:  time.Millisecond * 100,
+		close:     make(chan struct{}),
+		log:       logging.NewDefaultLoggerFactory().NewLogger("nack_generator"),
 	}
 
 	for _, opt := range opts {

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -13,7 +13,7 @@ import (
 type ResponderInterceptor struct {
 	interceptor.NoOp
 	size    uint16
-	streams *sync.Map
+	streams sync.Map
 	log     logging.LeveledLogger
 }
 
@@ -25,9 +25,8 @@ type localStream struct {
 // NewResponderInterceptor returns a new GeneratorInterceptor interceptor
 func NewResponderInterceptor(opts ...ResponderOption) (*ResponderInterceptor, error) {
 	r := &ResponderInterceptor{
-		size:    8192,
-		streams: &sync.Map{},
-		log:     logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
+		size: 8192,
+		log:  logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
#### Description

sync.Map is never copied, therefore a pointer is not necessary.
