### PR TITLE
Scream cgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/sean-der) - *Original Author*
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Alessandro Ros](https://github.com/aler9)
+* [Mathis Engelbart](https://github.com/mengelbart)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pion/interceptor
 go 1.15
 
 require (
-	github.com/mengelbart/scream-go v0.2.1
+	github.com/mengelbart/scream-go v0.2.2
 	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.6
 	github.com/pion/rtp v1.6.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pion/interceptor
 go 1.15
 
 require (
-	github.com/mengelbart/scream-go v0.2.0
+	github.com/mengelbart/scream-go v0.2.1
 	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.6
 	github.com/pion/rtp v1.6.2

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pion/interceptor
 go 1.15
 
 require (
+	github.com/mengelbart/scream-go v0.2.0
 	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.6
 	github.com/pion/rtp v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mengelbart/scream-go v0.2.0 h1:ElMV+/Z2rOE/H4XPvL0vtYQihb4IQ8bIJlf7boC+UGc=
+github.com/mengelbart/scream-go v0.2.0/go.mod h1:Yre6kUFLW62SKaIjBBZF/E93fEBqcCqn6bZyrjljd5k=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/randutil v0.1.0 h1:CFG1UdESneORglEsnimhUjf33Rwjubwj6xfiOXBa3mA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mengelbart/scream-go v0.2.0 h1:ElMV+/Z2rOE/H4XPvL0vtYQihb4IQ8bIJlf7boC+UGc=
 github.com/mengelbart/scream-go v0.2.0/go.mod h1:Yre6kUFLW62SKaIjBBZF/E93fEBqcCqn6bZyrjljd5k=
+github.com/mengelbart/scream-go v0.2.1 h1:neundJH6CnmPjeMXzj+auNePtq/hfjsLHzukub9No2U=
+github.com/mengelbart/scream-go v0.2.1/go.mod h1:Yre6kUFLW62SKaIjBBZF/E93fEBqcCqn6bZyrjljd5k=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/randutil v0.1.0 h1:CFG1UdESneORglEsnimhUjf33Rwjubwj6xfiOXBa3mA=

--- a/pkg/scream/receiver_interceptor.go
+++ b/pkg/scream/receiver_interceptor.go
@@ -1,0 +1,149 @@
+//+build scream
+
+package scream
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mengelbart/scream-go"
+	"github.com/pion/interceptor"
+	"github.com/pion/logging"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+// TODO: This is copied from the report interceptor, maybe there's a better place for this?
+func ntpTime(t time.Time) uint64 {
+	// seconds since 1st January 1900
+	s := (float64(t.UnixNano()) / 1000000000) + 2208988800
+
+	// higher 32 bits are the integer part, lower 32 bits are the fractional part
+	integerPart := uint32(s)
+	fractionalPart := uint32((s - float64(integerPart)) * 0xFFFFFFFF)
+	return uint64(integerPart)<<32 | uint64(fractionalPart)
+}
+
+// ReceiverInterceptor generates Feedback for SCReAM congestion control
+type ReceiverInterceptor struct {
+	interceptor.NoOp
+	m     sync.Mutex
+	wg    sync.WaitGroup
+	close chan struct{}
+	log   logging.LeveledLogger
+
+	screamRx   map[uint32]*scream.Rx
+	screamRxMu sync.Mutex
+	interval   time.Duration
+}
+
+// NewReceiverInterceptor returns a new ReceiverInterceptor
+func NewReceiverInterceptor() *ReceiverInterceptor {
+	return &ReceiverInterceptor{
+		interval: time.Millisecond * 10,
+		close:    make(chan struct{}),
+		log:      logging.NewDefaultLoggerFactory().NewLogger("scream_receiver"),
+		screamRx: map[uint32]*scream.Rx{},
+	}
+}
+
+// BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
+// will be called once per packet batch.
+func (r *ReceiverInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interceptor.RTCPWriter {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if r.isClosed() {
+		return writer
+	}
+
+	r.wg.Add(1)
+
+	go r.loop(writer)
+
+	return writer
+}
+
+// BindRemoteStream lets you modify any incoming RTP packets. It is called once for per RemoteStream. The returned method
+// will be called once per rtp packet.
+func (r *ReceiverInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reader interceptor.RTPReader) interceptor.RTPReader {
+	// TODO: Check if stream supports scream?
+
+	rx := scream.NewRx(info.SSRC)
+	r.screamRxMu.Lock()
+	r.screamRx[info.SSRC] = rx
+	r.screamRxMu.Unlock()
+
+	return interceptor.RTPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+		i, attr, err := reader.Read(b, a)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		pkt := rtp.Packet{}
+		if err = pkt.Unmarshal(b[:i]); err != nil {
+			return 0, nil, err
+		}
+
+		// TODO: Add support for ECN via ceBits?
+		rx.Receive(ntpTime(time.Now()), pkt.SSRC, len(pkt.Raw), pkt.SequenceNumber, 0)
+		return i, attr, nil
+	})
+}
+
+// UnbindRemoteStream is called when the Stream is removed. It can be used to clean up any data related to that track.
+func (r *ReceiverInterceptor) UnbindRemoteStream(info *interceptor.StreamInfo) {
+	r.screamRxMu.Lock()
+	delete(r.screamRx, info.SSRC)
+	r.screamRxMu.Unlock()
+}
+
+// Close closes the interceptor.
+func (r *ReceiverInterceptor) Close() error {
+	defer r.wg.Wait()
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if !r.isClosed() {
+		close(r.close)
+	}
+	return nil
+}
+
+func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			func() {
+				r.screamRxMu.Lock()
+
+				for _, rx := range r.screamRx {
+					// TODO: Check meaning of isMark
+					if ok, feedback := rx.CreateStandardizedFeedback(0, true); ok {
+						fb := rtcp.RawPacket(feedback)
+						if _, err := rtcpWriter.Write([]rtcp.Packet{&fb}, interceptor.Attributes{}); err != nil {
+							r.log.Warnf("failed sending scream feedback report: %+v", err)
+						}
+					}
+				}
+
+				r.screamRxMu.Unlock()
+			}()
+		case <-r.close:
+			return
+		}
+	}
+}
+
+func (r *ReceiverInterceptor) isClosed() bool {
+	select {
+	case <-r.close:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/scream/receiver_interceptor.go
+++ b/pkg/scream/receiver_interceptor.go
@@ -131,7 +131,7 @@ func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 
 				for _, rx := range r.screamRx {
 					// TODO: Check meaning of isMark
-					if ok, feedback := rx.CreateStandardizedFeedback(0, true); ok {
+					if ok, feedback := rx.CreateStandardizedFeedback(ntpTime(time.Now()), true); ok {
 						fb := rtcp.RawPacket(feedback)
 						if _, err := rtcpWriter.Write([]rtcp.Packet{&fb}, interceptor.Attributes{}); err != nil {
 							r.log.Warnf("failed sending scream feedback report: %+v", err)

--- a/pkg/scream/receiver_interceptor_test.go
+++ b/pkg/scream/receiver_interceptor_test.go
@@ -16,42 +16,67 @@ import (
 )
 
 func TestReceiverInterceptor(t *testing.T) {
-	const interval = time.Millisecond * 10
+	t.Run("sends-feedback", func(t *testing.T) {
+		const interval = time.Millisecond * 10
 
-	i, err := NewReceiverInterceptor()
-	assert.NoError(t, err)
+		i, err := NewReceiverInterceptor()
+		assert.NoError(t, err)
 
-	stream := test.NewMockStream(&interceptor.StreamInfo{
-		RTCPFeedback: []interceptor.RTCPFeedback{{
-			Type:      "ack",
-			Parameter: "ccfb",
-		}},
-	}, i)
-	defer func() {
-		assert.NoError(t, stream.Close())
-	}()
+		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SSRC: 0,
+			RTCPFeedback: []interceptor.RTCPFeedback{{
+				Type:      "ack",
+				Parameter: "ccfb",
+			}},
+		}, i)
+		defer func() {
+			assert.NoError(t, stream.Close())
+		}()
 
-	for _, seqNum := range []uint16{10, 11, 12, 13} {
-		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}})
+		for _, seqNum := range []uint16{10, 11, 12, 13} {
+			stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}})
+
+			select {
+			case r := <-stream.ReadRTP():
+				assert.NoError(t, r.Err)
+				assert.Equal(t, seqNum, r.Packet.SequenceNumber)
+			case <-time.After(10 * time.Millisecond):
+				t.Fatal("receiver rtp packet not found")
+			}
+		}
 
 		select {
-		case r := <-stream.ReadRTP():
-			assert.NoError(t, r.Err)
-			assert.Equal(t, seqNum, r.Packet.SequenceNumber)
-		case <-time.After(10 * time.Millisecond):
-			t.Fatal("receiver rtp packet not found")
+		case pkts := <-stream.WrittenRTCP():
+			assert.Equal(t, 1, len(pkts), "single packet RTCP Compound Packet expected")
+
+			p, ok := pkts[0].(*rtcp.RawPacket)
+			assert.True(t, ok, "RawPacket rtcp packet expected, found: %T", pkts[0])
+
+			assert.Equal(t, rtcp.PacketType(205), p.Header().Type)
+		case <-time.After(2 * interval):
+			t.Fatal("written rtcp packet not found")
 		}
-	}
+	})
 
-	select {
-	case pkts := <-stream.WrittenRTCP():
-		assert.Equal(t, 1, len(pkts), "single packet RTCP Compound Packet expected")
+	t.Run("doesn't crash on unsupported stream", func(t *testing.T) {
+		i, err := NewReceiverInterceptor()
+		assert.NoError(t, err)
 
-		p, ok := pkts[0].(*rtcp.RawPacket)
-		assert.True(t, ok, "RawPacket rtcp packet expected, found: %T", pkts[0])
+		stream := test.NewMockStream(&interceptor.StreamInfo{SSRC: 0}, i)
+		defer func() {
+			assert.NoError(t, stream.Close())
+		}()
 
-		assert.Equal(t, rtcp.PacketType(205), p.Header().Type)
-	case <-time.After(2 * interval):
-		t.Fatal("written rtcp packet not found")
-	}
+		for _, seqNum := range []uint16{10, 11, 12, 13} {
+			stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}})
+
+			select {
+			case r := <-stream.ReadRTP():
+				assert.NoError(t, r.Err)
+				assert.Equal(t, seqNum, r.Packet.SequenceNumber)
+			case <-time.After(10 * time.Millisecond):
+				t.Fatal("receiver rtp packet not found")
+			}
+		}
+	})
 }

--- a/pkg/scream/receiver_interceptor_test.go
+++ b/pkg/scream/receiver_interceptor_test.go
@@ -1,0 +1,57 @@
+//+build scream
+
+package scream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/rtcp"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/test"
+	"github.com/pion/rtp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReceiverInterceptor(t *testing.T) {
+	const interval = time.Millisecond * 10
+
+	i, err := NewReceiverInterceptor()
+	assert.NoError(t, err)
+
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		RTCPFeedback: []interceptor.RTCPFeedback{{
+			Type:      "ack",
+			Parameter: "ccfb",
+		}},
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	for _, seqNum := range []uint16{10, 11, 12, 13} {
+		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}})
+
+		select {
+		case r := <-stream.ReadRTP():
+			assert.NoError(t, r.Err)
+			assert.Equal(t, seqNum, r.Packet.SequenceNumber)
+		case <-time.After(10 * time.Millisecond):
+			t.Fatal("receiver rtp packet not found")
+		}
+	}
+
+	select {
+	case pkts := <-stream.WrittenRTCP():
+		assert.Equal(t, 1, len(pkts), "single packet RTCP Compound Packet expected")
+
+		p, ok := pkts[0].(*rtcp.RawPacket)
+		assert.True(t, ok, "RawPacket rtcp packet expected, found: %T", pkts[0])
+
+		assert.Equal(t, rtcp.PacketType(205), p.Header().Type)
+	case <-time.After(2 * interval):
+		t.Fatal("written rtcp packet not found")
+	}
+}

--- a/pkg/scream/receiver_option.go
+++ b/pkg/scream/receiver_option.go
@@ -1,0 +1,16 @@
+//+build scream
+
+package scream
+
+import "time"
+
+// ReceiverOption can be used to configure SenderInterceptor.
+type ReceiverOption func(r *ReceiverInterceptor) error
+
+// ReceiverInterval sets the feedback send interval for the interceptor
+func ReceiverInterval(interval time.Duration) ReceiverOption {
+	return func(s *ReceiverInterceptor) error {
+		s.interval = interval
+		return nil
+	}
+}

--- a/pkg/scream/rtp_queue.go
+++ b/pkg/scream/rtp_queue.go
@@ -1,0 +1,124 @@
+//+build scream
+
+package scream
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/pion/rtp"
+)
+
+type rtpQueueItem struct {
+	packet *rtp.Packet
+	ts     uint64
+}
+
+type queue struct {
+	m sync.RWMutex
+
+	bytesInQueue int
+	queue        *list.List
+}
+
+func newQueue() *queue {
+	return &queue{queue: list.New()}
+}
+
+func (q *queue) SizeOfNextRTP() int {
+	q.m.RLock()
+	defer q.m.RUnlock()
+
+	if q.queue.Len() <= 0 {
+		return 0
+	}
+
+	return q.queue.Front().Value.(rtpQueueItem).packet.MarshalSize()
+}
+
+func (q *queue) SeqNrOfNextRTP() uint16 {
+	q.m.RLock()
+	defer q.m.RUnlock()
+
+	if q.queue.Len() <= 0 {
+		return 0
+	}
+
+	return q.queue.Front().Value.(rtpQueueItem).packet.SequenceNumber
+}
+
+func (q *queue) BytesInQueue() int {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	return q.bytesInQueue
+}
+
+func (q *queue) SizeOfQueue() int {
+	q.m.RLock()
+	defer q.m.RUnlock()
+
+	return q.queue.Len()
+}
+
+func (q *queue) GetDelay(ts float32) float32 {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	if q.queue.Len() <= 0 {
+		return 0
+	}
+	pkt := q.queue.Front().Value.(rtpQueueItem)
+	ntpTime := pkt.ts
+	// First convert 64 bit NTP timestamp to 32 bit NTP timestamp as used by scream
+	q16Time := uint32((ntpTime >> 16) & 0xFFFFFFFF)
+	// Then scale the timestamp to seconds as done by scream and calculate the difference to given ts
+	delay := ts - float32(q16Time)/65536.0
+
+	return delay
+}
+
+func (q *queue) GetSizeOfLastFrame() int {
+	q.m.RLock()
+	defer q.m.RUnlock()
+
+	if q.queue.Len() <= 0 {
+		return 0
+	}
+
+	return q.queue.Back().Value.(rtpQueueItem).packet.MarshalSize()
+}
+
+func (q *queue) Clear() {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	q.bytesInQueue = 0
+	q.queue.Init()
+}
+
+func (q *queue) enqueue(packet *rtp.Packet, ts uint64) {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	q.bytesInQueue += packet.MarshalSize()
+	q.queue.PushBack(rtpQueueItem{
+		packet: packet,
+		ts:     ts,
+	})
+}
+
+func (q *queue) dequeue() *rtp.Packet {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	if q.queue.Len() <= 0 {
+		return nil
+	}
+
+	front := q.queue.Front()
+	q.queue.Remove(front)
+	packet := front.Value.(rtpQueueItem).packet
+	q.bytesInQueue -= packet.MarshalSize()
+	return packet
+}

--- a/pkg/scream/rtp_queue.go
+++ b/pkg/scream/rtp_queue.go
@@ -69,13 +69,9 @@ func (q *queue) GetDelay(ts float32) float32 {
 		return 0
 	}
 	pkt := q.queue.Front().Value.(rtpQueueItem)
-	ntpTime := pkt.ts
-	// First convert 64 bit NTP timestamp to 32 bit NTP timestamp as used by scream
-	q16Time := uint32((ntpTime >> 16) & 0xFFFFFFFF)
-	// Then scale the timestamp to seconds as done by scream and calculate the difference to given ts
-	delay := ts - float32(q16Time)/65536.0
 
-	return delay
+	// SCReAM expects a diff in seconds, thus we take the NTP seconds from the packet timestamp
+	return ts - float32((pkt.ts>>32)&0xFFFFFFFF_FFFFFFFF)
 }
 
 func (q *queue) GetSizeOfLastFrame() int {

--- a/pkg/scream/rtp_queue.go
+++ b/pkg/scream/rtp_queue.go
@@ -21,7 +21,7 @@ type queue struct {
 	queue        *list.List
 }
 
-func newQueue() *queue {
+func newQueue() RTPQueue {
 	return &queue{queue: list.New()}
 }
 
@@ -97,7 +97,7 @@ func (q *queue) Clear() {
 	q.queue.Init()
 }
 
-func (q *queue) enqueue(packet *rtp.Packet, ts uint64) {
+func (q *queue) Enqueue(packet *rtp.Packet, ts uint64) {
 	q.m.Lock()
 	defer q.m.Unlock()
 
@@ -108,7 +108,7 @@ func (q *queue) enqueue(packet *rtp.Packet, ts uint64) {
 	})
 }
 
-func (q *queue) dequeue() *rtp.Packet {
+func (q *queue) Dequeue() *rtp.Packet {
 	q.m.Lock()
 	defer q.m.Unlock()
 

--- a/pkg/scream/rtp_queue_test.go
+++ b/pkg/scream/rtp_queue_test.go
@@ -1,0 +1,115 @@
+//+build scream
+
+package scream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pion/rtp"
+)
+
+func Test_queue_EnqueueDequeue(t *testing.T) {
+	type input struct {
+		pkt *rtp.Packet
+		ts  uint64
+	}
+	tests := []struct {
+		name string
+		data []input
+	}{
+		{
+			name: "dequeue-empty",
+		},
+		{
+			name: "enqueue-dequeue-1",
+			data: []input{{pkt: &rtp.Packet{}, ts: 100000}},
+		},
+		{
+			name: "enqueue-dequeue-2",
+			data: []input{{pkt: &rtp.Packet{}, ts: 10000000}, {pkt: &rtp.Packet{}, ts: 200000}},
+		},
+		{
+			name: "enqueue-dequeue-3",
+			data: []input{{pkt: &rtp.Packet{Payload: []byte{0x01, 0x02, 0x03}}, ts: 120000}, {pkt: &rtp.Packet{Payload: []byte{0x01, 0x02, 0x03}}, ts: 163456}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newQueue()
+
+			bytes := 0
+			for i, pkt := range tt.data {
+				frameSize := 12 + len(pkt.pkt.Payload)
+				bytes += frameSize
+
+				q.Enqueue(pkt.pkt, pkt.ts)
+
+				assert.Equal(t, i+1, q.SizeOfQueue())
+				assert.Equal(t, bytes, q.BytesInQueue())
+				assert.Equal(t, frameSize, q.GetSizeOfLastFrame())
+				assert.Equal(t, tt.data[0].pkt.SequenceNumber, q.SeqNrOfNextRTP())
+				assert.Equal(t, 12+len(tt.data[0].pkt.Payload), q.SizeOfNextRTP())
+			}
+
+			for i := range tt.data {
+				got := q.Dequeue()
+
+				frameSize := 12 + len(got.Payload)
+				bytes -= frameSize
+
+				assert.Equal(t, tt.data[i].pkt, got)
+				assert.Equal(t, len(tt.data)-(i+1), q.SizeOfQueue())
+				assert.Equal(t, bytes, q.BytesInQueue())
+			}
+
+			for _, pkt := range tt.data {
+				q.Enqueue(pkt.pkt, pkt.ts)
+			}
+
+			q.Clear()
+
+			assert.Equal(t, 0, q.SizeOfQueue())
+			assert.Equal(t, 0, q.BytesInQueue())
+		})
+	}
+}
+
+func Test_queue_GetDelay(t *testing.T) {
+	tests := []struct {
+		name  string
+		input uint64
+		ts    float32
+		want  float32
+	}{
+		{
+			name: "zero",
+		},
+		{
+			name:  "shift-65536-zero-delay",
+			input: 65536 << 16,
+			ts:    1,
+		},
+		{
+			name:  "shift-1-zero-delay",
+			input: 1 << 32,
+			ts:    1,
+		},
+		{
+			name:  "shift-2-1-delay",
+			input: 2 << 32,
+			ts:    3,
+			want:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newQueue()
+			q.Enqueue(&rtp.Packet{}, tt.input)
+
+			got := q.GetDelay(tt.ts)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/scream/scream.go
+++ b/pkg/scream/scream.go
@@ -2,3 +2,15 @@
 
 // Package scream provides interceptors to implement SCReAM congestion control via cgo
 package scream
+
+import "github.com/pion/interceptor"
+
+func streamSupportSCReAM(info *interceptor.StreamInfo) bool {
+	for _, fb := range info.RTCPFeedback {
+		if fb.Type == "ack" && fb.Parameter == "ccfb" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/scream/scream.go
+++ b/pkg/scream/scream.go
@@ -1,0 +1,4 @@
+//+build scream
+
+// Package scream provides interceptors to implement SCReAM congestion control via cgo
+package scream

--- a/pkg/scream/sender_interceptor.go
+++ b/pkg/scream/sender_interceptor.go
@@ -107,18 +107,18 @@ func (s *SenderInterceptor) BindLocalStream(info *interceptor.StreamInfo, writer
 	rtpQueue := s.newRTPQueue()
 	localStream := &localStream{
 		queue:       rtpQueue,
-		newFrame:    make(chan struct{}, 1024), // TODO: remove hardcoded limit?
-		newFeedback: make(chan struct{}, 1024), // TODO: remove hardcoded limit?
+		newFrame:    make(chan struct{}),
+		newFeedback: make(chan struct{}),
 	}
 	s.rtpStreamsMu.Lock()
 	s.rtpStreams[info.SSRC] = localStream
 	s.rtpStreamsMu.Unlock()
 
 	// TODO: Somehow set these attributes per stream
-	priority := float64(1)               // highest priority
-	minBitrate := float64(1_000)         // 1Kbps
-	startBitrate := float64(1_000)       // 1Kbps
-	maxBitrate := float64(1_000_000_000) // 1Mbps
+	priority := float64(1)            // highest priority
+	minBitrate := float64(1_000)      // 1Kbps
+	startBitrate := float64(1_000)    // 1Kbps
+	maxBitrate := float64(50_000_000) // 50Mbps
 
 	s.tx.RegisterNewStream(rtpQueue, info.SSRC, priority, minBitrate, startBitrate, maxBitrate)
 

--- a/pkg/scream/sender_interceptor.go
+++ b/pkg/scream/sender_interceptor.go
@@ -1,0 +1,229 @@
+//+build scream
+
+package scream
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mengelbart/scream-go"
+	"github.com/pion/interceptor"
+	"github.com/pion/logging"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+type rtpQueue interface {
+	scream.RTPQueue
+	enqueue(packet *rtp.Packet, ts uint64)
+	dequeue() *rtp.Packet
+}
+
+type localStream struct {
+	queue       rtpQueue
+	newFrame    chan struct{}
+	newFeedback chan struct{}
+	close       chan struct{}
+}
+
+// SenderInterceptor performs SCReAM congestion control
+type SenderInterceptor struct {
+	interceptor.NoOp
+	m     sync.Mutex
+	wg    sync.WaitGroup
+	tx    *scream.Tx
+	close chan struct{}
+	log   logging.LeveledLogger
+
+	rtpStreams   map[uint32]*localStream
+	rtpStreamsMu sync.Mutex
+}
+
+// NewSenderInterceptor returns a new SenderInterceptor
+func NewSenderInterceptor() *SenderInterceptor {
+	return &SenderInterceptor{
+		tx:         scream.NewTx(),
+		close:      make(chan struct{}),
+		log:        logging.NewDefaultLoggerFactory().NewLogger("scream_sender"),
+		rtpStreams: map[uint32]*localStream{},
+	}
+}
+
+// BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
+// change in the future. The returned method will be called once per packet batch.
+func (s *SenderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) interceptor.RTCPReader {
+	return interceptor.RTCPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+		n, attr, err := reader.Read(b, a)
+		if err != nil {
+			return 0, nil, err
+		}
+		pkts, err := rtcp.Unmarshal(b[:n])
+		if err != nil {
+			return 0, nil, err
+		}
+		for _, rtcpPacket := range pkts {
+			s.m.Lock()
+			s.tx.IncomingStandardizedFeedback(ntpTime(time.Now()), b[:n])
+			s.m.Unlock()
+
+			for _, ssrc := range rtcpPacket.DestinationSSRC() {
+				s.rtpStreamsMu.Lock()
+				s.rtpStreams[ssrc].newFeedback <- struct{}{}
+				s.rtpStreamsMu.Unlock()
+			}
+		}
+
+		return n, attr, nil
+	})
+}
+
+// BindLocalStream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
+// will be called once per rtp packet.
+func (s *SenderInterceptor) BindLocalStream(info *interceptor.StreamInfo, writer interceptor.RTPWriter) interceptor.RTPWriter {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.isClosed() {
+		return writer
+	}
+
+	s.wg.Add(1)
+
+	rtpQueue := newQueue() // TODO: Use a configurable factory?
+	localStream := &localStream{
+		queue:       rtpQueue,
+		newFrame:    make(chan struct{}, 1024), // TODO: remove hardcoded limit?
+		newFeedback: make(chan struct{}, 1024), // TODO: remove hardcoded limit?
+	}
+	s.rtpStreamsMu.Lock()
+	s.rtpStreams[info.SSRC] = localStream
+	s.rtpStreamsMu.Unlock()
+
+	// TODO: Somehow set these attributes per stream
+	priority := float64(1)               // highest priority
+	minBitrate := float64(1_000)         // 1Kbps
+	startBitrate := float64(1_000)       // 1Kbps
+	maxBitrate := float64(1_000_000_000) // 1Mbps
+
+	s.tx.RegisterNewStream(rtpQueue, info.SSRC, priority, minBitrate, startBitrate, maxBitrate)
+
+	go s.loop(writer, info.SSRC)
+
+	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
+		t := ntpTime(time.Now())
+		pkt := &rtp.Packet{Header: *header, Payload: payload}
+		rtpQueue.enqueue(pkt, t)
+		size := pkt.MarshalSize()
+		s.m.Lock()
+		s.tx.NewMediaFrame(t, header.SSRC, size)
+		s.m.Unlock()
+		localStream.newFeedback <- struct{}{}
+		return size, nil
+	})
+}
+
+// UnbindLocalStream is called when the Stream is removed. It can be used to clean up any data related to that track.
+func (s *SenderInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
+	s.rtpStreamsMu.Lock()
+	defer s.rtpStreamsMu.Unlock()
+	close(s.rtpStreams[info.SSRC].close)
+	delete(s.rtpStreams, info.SSRC)
+}
+
+// Close closes the interceptor
+func (s *SenderInterceptor) Close() error {
+	defer s.wg.Wait()
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if !s.isClosed() {
+		close(s.close)
+	}
+	return nil
+}
+
+func (s *SenderInterceptor) loop(writer interceptor.RTPWriter, ssrc uint32) {
+	s.rtpStreamsMu.Lock()
+	stream := s.rtpStreams[ssrc]
+	s.rtpStreamsMu.Unlock()
+
+	// TODO: A bit ugly? We need a timer so that case <-timer.C doesn't segfault.
+	// however, that case only applies after the timer has explicitly been set in one
+	// of the other cases first. So the timer will be disabled by default in the beginning.
+	// The algorithm implemented here is documented in detail (a flow chart) here:
+	// https://github.com/EricssonResearch/scream/blob/master/SCReAM-description.pptx
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	timerRunning := false
+	defer s.log.Infof("leave send loop for ssrc: %v", ssrc)
+
+	for {
+		select {
+		case <-timer.C:
+			timerRunning = false
+		case <-stream.newFrame:
+			if timerRunning {
+				continue
+			}
+		case <-stream.newFeedback:
+			if timerRunning {
+				continue
+			}
+		case <-s.close:
+			return
+		}
+
+		if stream.queue.SizeOfQueue() <= 0 {
+			continue
+		}
+
+		s.m.Lock()
+		transmit := s.tx.IsOkToTransmit(ntpTime(time.Now()), ssrc)
+		s.m.Unlock()
+		switch {
+		case transmit == -1:
+			// no packets or CWND too small
+			continue
+
+		case transmit <= 1e-3:
+			// send packet
+			packet := stream.queue.dequeue()
+			if packet == nil {
+				continue
+			}
+			t := time.Now()
+			// TODO: Forward attributes from above?
+			if _, err := writer.Write(&packet.Header, packet.Payload, interceptor.Attributes{}); err != nil {
+				s.log.Warnf("failed sending RTP packet: %+v", err)
+			}
+			s.m.Lock()
+			// TODO: set isMark?
+			transmit = s.tx.AddTransmitted(ntpTime(t), ssrc, packet.MarshalSize(), packet.SequenceNumber, false)
+			s.m.Unlock()
+			if transmit == -1 {
+				continue
+			}
+		}
+		// Set timer: transmit is float in seconds, i.e. 0.123 seconds.
+		timer = time.NewTimer(time.Duration(transmit*1000.0) * time.Millisecond)
+		timerRunning = true
+	}
+}
+
+// GetTargetBitrate returns the target bitrate calculated by SCReAM in bps.
+func (s *SenderInterceptor) GetTargetBitrate(ssrc uint32) int64 {
+	s.m.Lock()
+	defer s.m.Unlock()
+	return s.tx.GetTargetBitrate(ssrc)
+}
+
+func (s *SenderInterceptor) isClosed() bool {
+	select {
+	case <-s.close:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/scream/sender_interceptor.go
+++ b/pkg/scream/sender_interceptor.go
@@ -160,6 +160,7 @@ func (s *SenderInterceptor) Close() error {
 }
 
 func (s *SenderInterceptor) loop(writer interceptor.RTPWriter, ssrc uint32) {
+	defer s.wg.Done()
 	s.rtpStreamsMu.Lock()
 	stream := s.rtpStreams[ssrc]
 	s.rtpStreamsMu.Unlock()

--- a/pkg/scream/sender_interceptor_test.go
+++ b/pkg/scream/sender_interceptor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/rtcp"
+
 	"github.com/pion/interceptor"
 	"github.com/pion/interceptor/internal/test"
 	"github.com/pion/rtp"
@@ -13,33 +15,113 @@ import (
 )
 
 func TestSenderInterceptor(t *testing.T) {
-	i, err := NewSenderInterceptor()
-	assert.NoError(t, err)
+	t.Run("sends RTP", func(t *testing.T) {
+		i, err := NewSenderInterceptor()
+		assert.NoError(t, err)
 
-	stream := test.NewMockStream(&interceptor.StreamInfo{
-		RTCPFeedback: []interceptor.RTCPFeedback{{
-			Type:      "ack",
-			Parameter: "ccfb",
-		}},
-	}, i)
-	defer func() {
-		assert.NoError(t, stream.Close())
-	}()
+		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SSRC: 0,
+			RTCPFeedback: []interceptor.RTCPFeedback{{
+				Type:      "ack",
+				Parameter: "ccfb",
+			}},
+		}, i)
+		defer func() {
+			assert.NoError(t, stream.Close())
+		}()
 
-	for _, seqNum := range []uint16{10, 11, 12, 13, 14, 15} {
-		assert.NoError(t, stream.WriteRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}}))
+		for _, seqNum := range []uint16{10, 11, 12, 13, 14, 15} {
+			assert.NoError(t, stream.WriteRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}}))
+
+			select {
+			case p := <-stream.WrittenRTP():
+				assert.Equal(t, seqNum, p.SequenceNumber)
+			case <-time.After(10 * time.Millisecond):
+				t.Fatal("written rtp packet not found")
+			}
+		}
 
 		select {
 		case p := <-stream.WrittenRTP():
-			assert.Equal(t, seqNum, p.SequenceNumber)
+			t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
 		}
-	}
+	})
 
-	select {
-	case p := <-stream.WrittenRTP():
-		t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
-	case <-time.After(10 * time.Millisecond):
+	t.Run("doesn't crash on unsupported stream", func(t *testing.T) {
+		i, err := NewSenderInterceptor()
+		assert.NoError(t, err)
+
+		stream := test.NewMockStream(&interceptor.StreamInfo{SSRC: 4294967295}, i)
+		defer func() {
+			assert.NoError(t, stream.Close())
+		}()
+
+		for _, seqNum := range []uint16{10, 11, 12, 13, 14, 15} {
+			assert.NoError(t, stream.WriteRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}}))
+
+			select {
+			case p := <-stream.WrittenRTP():
+				assert.Equal(t, seqNum, p.SequenceNumber)
+			case <-time.After(10 * time.Millisecond):
+				t.Fatal("written rtp packet not found")
+			}
+		}
+
+		_, err = i.GetTargetBitrate(0)
+		assert.Error(t, err)
+
+		stream.ReceiveRTCP([]rtcp.Packet{
+			&rtcp.RawPacket{128, 205, 0, 9, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+		})
+
+		time.Sleep(1 * time.Second)
+
+		select {
+		case p := <-stream.WrittenRTP():
+			t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
+		case <-time.After(10 * time.Millisecond):
+		}
+	})
+}
+
+func Test_extractSSRCs(t *testing.T) {
+	header := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	timestamp := []byte{0, 0, 0, 0}
+	tests := []struct {
+		name   string
+		packet []byte
+		want   []uint32
+	}{
+		{
+			name:   "empty",
+			packet: append(append(header, []byte{}...), timestamp...),
+		},
+		{
+			name:   "one ssrc",
+			packet: append(append(header, []byte{255, 255, 255, 255, 0, 1, 0, 2, 0, 0, 0, 0}...), timestamp...),
+			want:   []uint32{4294967295},
+		},
+		{
+			name:   "two ssrcs",
+			packet: append(append(header, []byte{255, 255, 255, 255, 0, 1, 0, 1, 0, 0, 0, 0, 255, 255, 255, 254, 0, 1, 0, 1, 0, 0, 0, 0}...), timestamp...),
+			want:   []uint32{4294967295, 4294967294},
+		},
+		{
+			name:   "duplicate ssrcs",
+			packet: append(append(header, []byte{255, 255, 255, 255, 0, 1, 0, 1, 0, 0, 0, 0, 255, 255, 255, 255, 0, 1, 0, 1, 0, 0, 0, 0}...), timestamp...),
+			want:   []uint32{4294967295},
+		},
+		{
+			name:   "overflow seq num",
+			packet: append(append(header, []byte{255, 255, 255, 255, 255, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 254, 0, 1, 0, 1, 0, 0, 0, 0}...), timestamp...),
+			want:   []uint32{4294967295, 4294967294},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSSRCs(tt.packet)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/pkg/scream/sender_interceptor_test.go
+++ b/pkg/scream/sender_interceptor_test.go
@@ -1,0 +1,45 @@
+//+build scream
+
+package scream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/test"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSenderInterceptor(t *testing.T) {
+	i, err := NewSenderInterceptor()
+	assert.NoError(t, err)
+
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		RTCPFeedback: []interceptor.RTCPFeedback{{
+			Type:      "ack",
+			Parameter: "ccfb",
+		}},
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	for _, seqNum := range []uint16{10, 11, 12, 13, 14, 15} {
+		assert.NoError(t, stream.WriteRTP(&rtp.Packet{Header: rtp.Header{SequenceNumber: seqNum}}))
+
+		select {
+		case p := <-stream.WrittenRTP():
+			assert.Equal(t, seqNum, p.SequenceNumber)
+		case <-time.After(10 * time.Millisecond):
+			t.Fatal("written rtp packet not found")
+		}
+	}
+
+	select {
+	case p := <-stream.WrittenRTP():
+		t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
+	case <-time.After(10 * time.Millisecond):
+	}
+}

--- a/pkg/scream/sender_option.go
+++ b/pkg/scream/sender_option.go
@@ -2,6 +2,8 @@
 
 package scream
 
+import "github.com/mengelbart/scream-go"
+
 // SenderOption can be used to configure SenderInterceptor.
 type SenderOption func(r *SenderInterceptor) error
 
@@ -9,6 +11,13 @@ type SenderOption func(r *SenderInterceptor) error
 func SenderQueue(queueFactory func() RTPQueue) SenderOption {
 	return func(s *SenderInterceptor) error {
 		s.newRTPQueue = queueFactory
+		return nil
+	}
+}
+
+func Tx(tx *scream.Tx) SenderOption {
+	return func(s *SenderInterceptor) error {
+		s.tx = tx
 		return nil
 	}
 }

--- a/pkg/scream/sender_option.go
+++ b/pkg/scream/sender_option.go
@@ -1,0 +1,14 @@
+//+build scream
+
+package scream
+
+// SenderOption can be used to configure SenderInterceptor.
+type SenderOption func(r *SenderInterceptor) error
+
+// SenderQueue sets the factory function to create new RTP Queues for new streams.
+func SenderQueue(queueFactory func() RTPQueue) SenderOption {
+	return func(s *SenderInterceptor) error {
+		s.newRTPQueue = queueFactory
+		return nil
+	}
+}


### PR DESCRIPTION
#### Description

Implements Congestion Control using my [CGO Wrapper for SCReAM](https://github.com/mengelbart/scream-go/). Since it uses CGO, it is hidden behind the `scream` build tag.

There are no tests yet and there are some points about which I don't know how to deal with them, yet:

* My SCReAM wrapper wasn't reviewed or tested by anyone else then myself.
* ECN: The [SCReAM implementation](https://github.com/EricssonResearch/scream/) supports ECN, but I don't know how to actually set this.
* How to set the Marker bit? The documentation of the SCReAM implementation is a bit unclear to me and if I read the example correctly it is set after a batch of packets but I'm not sure if and how we can do this in an interceptor?
* Some attributes like min/max bitrate and start bitrate need to be set per stream, can I do this via new fields in `interceptor.StreamInfo`?
* How should attributes of buffered packets be handled? I guess I can just buffer them with the packet and pass them on to the next interceptor once the packet is dequeued?
* I copied the ntpTime function from the report interceptor, maybe this could be moved to another place where we can reuse it. But since this SCReAM implementation will not be released due to cgo, I'm not sure if it's actually necessary to have it somewhere else in general.