### PR TITLE
Add SessionID to interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/sean-der) - *Original Author*
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Alessandro Ros](https://github.com/aler9)
+* [Jerko Steiner](https://github.com/jeremija)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,35 @@
+package interceptor
+
+// Factory defines a way to create interface
+type Factory interface {
+	NewInterceptor(SessionID) (Interceptor, error)
+}
+
+// FactoryFunc defines a simpler interface to use when creating a Factory,
+// similar to http.HandlerFunc.
+type FactoryFunc func(SessionID) (Interceptor, error)
+
+// NewInterceptor implements Factory.
+func (f FactoryFunc) NewInterceptor(sessionID SessionID) (Interceptor, error) {
+	return f(sessionID)
+}
+
+// SharedFactory is the simplest implementation of Factory, it always returns
+// the same, already initialized Interceptor and expects it to be able to
+// handle streams from different contexts.
+type SharedFactory struct {
+	interceptor Interceptor
+}
+
+// NewSharedFactory creates a new instance of SharedFactory.
+func NewSharedFactory(interceptor Interceptor) *SharedFactory {
+	return &SharedFactory{
+		interceptor: interceptor,
+	}
+}
+
+// NewInterceptor always returns the same interceptor and ignores the SessionID
+// argument.
+func (s *SharedFactory) NewInterceptor(_ SessionID) (Interceptor, error) {
+	return s.interceptor, nil
+}

--- a/interceptor.go
+++ b/interceptor.go
@@ -3,11 +3,12 @@
 package interceptor
 
 import (
-	"io"
-
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 )
+
+// SessionID defines the unique ID of a session. For example, it could be the ID of a peer connection.
+type SessionID string
 
 // Interceptor can be used to add functionality to you PeerConnections by modifying any incoming/outgoing rtp/rtcp
 // packets, or sending your own packets as needed.
@@ -15,11 +16,11 @@ type Interceptor interface {
 
 	// BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
 	// change in the future. The returned method will be called once per packet batch.
-	BindRTCPReader(reader RTCPReader) RTCPReader
+	BindRTCPReader(sessionID SessionID, reader RTCPReader) RTCPReader
 
 	// BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
 	// will be called once per packet batch.
-	BindRTCPWriter(writer RTCPWriter) RTCPWriter
+	BindRTCPWriter(sessionID SessionID, writer RTCPWriter) RTCPWriter
 
 	// BindLocalStream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
 	// will be called once per rtp packet.
@@ -35,7 +36,7 @@ type Interceptor interface {
 	// UnbindRemoteStream is called when the Stream is removed. It can be used to clean up any data related to that track.
 	UnbindRemoteStream(info *StreamInfo)
 
-	io.Closer
+	Close(sessionID SessionID) error
 }
 
 // RTPWriter is used by Interceptor.BindLocalStream.

--- a/internal/test/mock_stream_test.go
+++ b/internal/test/mock_stream_test.go
@@ -11,7 +11,13 @@ import (
 )
 
 func TestMockStream(t *testing.T) {
-	s := NewMockStream(&interceptor.StreamInfo{}, &interceptor.NoOp{})
+	sessionID := interceptor.SessionID("test")
+	s := NewMockStream(
+		&interceptor.StreamInfo{
+			SessionID: sessionID,
+		},
+		&interceptor.NoOp{},
+	)
 
 	assert.NoError(t, s.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{}}))
 
@@ -69,5 +75,5 @@ func TestMockStream(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 	}
 
-	assert.NoError(t, s.Close())
+	assert.NoError(t, s.Close(sessionID))
 }

--- a/noop.go
+++ b/noop.go
@@ -6,13 +6,13 @@ type NoOp struct{}
 
 // BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
 // change in the future. The returned method will be called once per packet batch.
-func (i *NoOp) BindRTCPReader(reader RTCPReader) RTCPReader {
+func (i *NoOp) BindRTCPReader(_ SessionID, reader RTCPReader) RTCPReader {
 	return reader
 }
 
 // BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
 // will be called once per packet batch.
-func (i *NoOp) BindRTCPWriter(writer RTCPWriter) RTCPWriter {
+func (i *NoOp) BindRTCPWriter(_ SessionID, writer RTCPWriter) RTCPWriter {
 	return writer
 }
 
@@ -35,6 +35,6 @@ func (i *NoOp) BindRemoteStream(_ *StreamInfo, reader RTPReader) RTPReader {
 func (i *NoOp) UnbindRemoteStream(_ *StreamInfo) {}
 
 // Close closes the Interceptor, cleaning up any data if necessary.
-func (i *NoOp) Close() error {
+func (i *NoOp) Close(sessionID SessionID) error {
 	return nil
 }

--- a/pkg/nack/generator_interceptor_test.go
+++ b/pkg/nack/generator_interceptor_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure GeneratorInterceptor satisfies the Interceptor interface.
+var _ interceptor.Interceptor = &GeneratorInterceptor{}
+
 func TestGeneratorInterceptor(t *testing.T) {
 	const interval = time.Millisecond * 10
 	i, err := NewGeneratorInterceptor(
@@ -22,12 +25,15 @@ func TestGeneratorInterceptor(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
+	sessionID := interceptor.SessionID("test")
+
 	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SessionID:    sessionID,
 		SSRC:         1,
 		RTCPFeedback: []interceptor.RTCPFeedback{{Type: "nack"}},
 	}, i)
 	defer func() {
-		assert.NoError(t, stream.Close())
+		assert.NoError(t, stream.Close(sessionID))
 	}()
 
 	for _, seqNum := range []uint16{10, 11, 12, 14, 16, 18} {

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -12,11 +12,10 @@ import (
 // ResponderInterceptor responds to nack feedback messages
 type ResponderInterceptor struct {
 	interceptor.NoOp
-	size uint16
-	log  logging.LeveledLogger
-
-	streams   map[uint32]*localStream
-	streamsMu sync.Mutex
+	size     uint16
+	log      logging.LeveledLogger
+	sessions map[interceptor.SessionID]map[uint32]*localStream
+	mu       sync.Mutex
 }
 
 type localStream struct {
@@ -27,9 +26,9 @@ type localStream struct {
 // NewResponderInterceptor returns a new GeneratorInterceptor interceptor
 func NewResponderInterceptor(opts ...ResponderOption) (*ResponderInterceptor, error) {
 	r := &ResponderInterceptor{
-		size:    8192,
-		log:     logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
-		streams: map[uint32]*localStream{},
+		size:     8192,
+		log:      logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
+		sessions: map[interceptor.SessionID]map[uint32]*localStream{},
 	}
 
 	for _, opt := range opts {
@@ -47,7 +46,7 @@ func NewResponderInterceptor(opts ...ResponderOption) (*ResponderInterceptor, er
 
 // BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
 // change in the future. The returned method will be called once per packet batch.
-func (n *ResponderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) interceptor.RTCPReader {
+func (n *ResponderInterceptor) BindRTCPReader(sessionID interceptor.SessionID, reader interceptor.RTCPReader) interceptor.RTCPReader {
 	return interceptor.RTCPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
 		i, attr, err := reader.Read(b, a)
 		if err != nil {
@@ -64,7 +63,7 @@ func (n *ResponderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) int
 				continue
 			}
 
-			go n.resendPackets(nack)
+			go n.resendPackets(sessionID, nack)
 		}
 
 		return i, attr, err
@@ -80,9 +79,14 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 
 	// error is already checked in NewGeneratorInterceptor
 	sendBuffer, _ := newSendBuffer(n.size)
-	n.streamsMu.Lock()
-	n.streams[info.SSRC] = &localStream{sendBuffer: sendBuffer, rtpWriter: writer}
-	n.streamsMu.Unlock()
+	n.mu.Lock()
+	ssrcs, ok := n.sessions[info.SessionID]
+	if !ok {
+		ssrcs = make(map[uint32]*localStream, 1)
+		n.sessions[info.SessionID] = ssrcs
+	}
+	ssrcs[info.SSRC] = &localStream{sendBuffer: sendBuffer, rtpWriter: writer}
+	n.mu.Unlock()
 
 	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
 		sendBuffer.add(&rtp.Packet{Header: *header, Payload: payload})
@@ -92,15 +96,15 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 
 // UnbindLocalStream is called when the Stream is removed. It can be used to clean up any data related to that track.
 func (n *ResponderInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
-	n.streamsMu.Lock()
-	delete(n.streams, info.SSRC)
-	n.streamsMu.Unlock()
+	n.mu.Lock()
+	delete(n.sessions[info.SessionID], info.SSRC)
+	n.mu.Unlock()
 }
 
-func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
-	n.streamsMu.Lock()
-	stream, ok := n.streams[nack.MediaSSRC]
-	n.streamsMu.Unlock()
+func (n *ResponderInterceptor) resendPackets(sessionID interceptor.SessionID, nack *rtcp.TransportLayerNack) {
+	n.mu.Lock()
+	stream, ok := n.sessions[sessionID][nack.MediaSSRC]
+	n.mu.Unlock()
 	if !ok {
 		return
 	}

--- a/pkg/nack/responder_interceptor_test.go
+++ b/pkg/nack/responder_interceptor_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure ResponderInterceptor satisfies the Interceptor interface.
+var _ interceptor.Interceptor = &ResponderInterceptor{}
+
 func TestResponderInterceptor(t *testing.T) {
 	i, err := NewResponderInterceptor(
 		ResponderSize(8),
@@ -19,12 +22,15 @@ func TestResponderInterceptor(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
+	sessionID := interceptor.SessionID("test")
+
 	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SessionID:    sessionID,
 		SSRC:         1,
 		RTCPFeedback: []interceptor.RTCPFeedback{{Type: "nack"}},
 	}, i)
 	defer func() {
-		assert.NoError(t, stream.Close())
+		assert.NoError(t, stream.Close(sessionID))
 	}()
 
 	for _, seqNum := range []uint16{10, 11, 12, 14, 15} {

--- a/pkg/report/receiver_interceptor.go
+++ b/pkg/report/receiver_interceptor.go
@@ -15,11 +15,9 @@ type ReceiverInterceptor struct {
 	interceptor.NoOp
 	interval time.Duration
 	now      func() time.Time
-	streams  sync.Map
+	sessions map[interceptor.SessionID]*receiverSessionCtx
 	log      logging.LeveledLogger
-	m        sync.Mutex
-	wg       sync.WaitGroup
-	close    chan struct{}
+	mu       sync.Mutex
 }
 
 // NewReceiverInterceptor returns a new ReceiverInterceptor interceptor.
@@ -27,8 +25,8 @@ func NewReceiverInterceptor(opts ...ReceiverOption) (*ReceiverInterceptor, error
 	r := &ReceiverInterceptor{
 		interval: 1 * time.Second,
 		now:      time.Now,
+		sessions: map[interceptor.SessionID]*receiverSessionCtx{},
 		log:      logging.NewDefaultLoggerFactory().NewLogger("receiver_interceptor"),
-		close:    make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -40,47 +38,64 @@ func NewReceiverInterceptor(opts ...ReceiverOption) (*ReceiverInterceptor, error
 	return r, nil
 }
 
-func (r *ReceiverInterceptor) isClosed() bool {
-	select {
-	case <-r.close:
-		return true
-	default:
-		return false
-	}
+type receiverSessionCtx struct {
+	streams  sync.Map
+	teardown chan struct{}
+	torndown chan struct{}
 }
 
 // Close closes the interceptor.
-func (r *ReceiverInterceptor) Close() error {
-	defer r.wg.Wait()
-	r.m.Lock()
-	defer r.m.Unlock()
+func (r *ReceiverInterceptor) Close(sessionID interceptor.SessionID) error {
+	r.mu.Lock()
+	sCtx, ok := r.sessions[sessionID]
+	delete(r.sessions, sessionID)
+	r.mu.Unlock()
 
-	if !r.isClosed() {
-		close(r.close)
+	if !ok {
+		// TODO(jeremija) maybe return an error?
+		return nil
 	}
+
+	// Close loop goroutine.
+	close(sCtx.teardown)
+
+	// Wait for the goroutine to exit.
+	<-sCtx.torndown
 
 	return nil
 }
 
+// newSession finds the current session by ID or creates a new one if it
+// doesn't exist. The caller must hold the lock.
+func (r *ReceiverInterceptor) newSession(sessionID interceptor.SessionID) *receiverSessionCtx {
+	sCtx := &receiverSessionCtx{
+		streams:  sync.Map{},
+		teardown: make(chan struct{}),
+		torndown: make(chan struct{}),
+	}
+	// TODO(jeremija) what if there are conflicts? The caller should ensure that
+	// sessionIDs are unique.
+	r.sessions[sessionID] = sCtx
+
+	return sCtx
+}
+
 // BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
 // will be called once per packet batch.
-func (r *ReceiverInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interceptor.RTCPWriter {
-	r.m.Lock()
-	defer r.m.Unlock()
+func (r *ReceiverInterceptor) BindRTCPWriter(sessionID interceptor.SessionID, writer interceptor.RTCPWriter) interceptor.RTCPWriter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	if r.isClosed() {
-		return writer
-	}
+	sCtx := r.newSession(sessionID)
 
-	r.wg.Add(1)
-
-	go r.loop(writer)
+	// TODO(jeremija) figure out if there's a way to run a single loop for all sessions.
+	go r.loop(sCtx, writer)
 
 	return writer
 }
 
-func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
-	defer r.wg.Done()
+func (r *ReceiverInterceptor) loop(sCtx *receiverSessionCtx, rtcpWriter interceptor.RTCPWriter) {
+	defer close(sCtx.torndown)
 
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
@@ -88,7 +103,7 @@ func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 		select {
 		case <-ticker.C:
 			now := r.now()
-			r.streams.Range(func(key, value interface{}) bool {
+			sCtx.streams.Range(func(key, value interface{}) bool {
 				stream := value.(*receiverStream)
 
 				var pkts []rtcp.Packet
@@ -102,7 +117,7 @@ func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 				return true
 			})
 
-		case <-r.close:
+		case <-sCtx.teardown:
 			return
 		}
 	}
@@ -112,7 +127,15 @@ func (r *ReceiverInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 // will be called once per rtp packet.
 func (r *ReceiverInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reader interceptor.RTPReader) interceptor.RTPReader {
 	stream := newReceiverStream(info.SSRC, info.ClockRate)
-	r.streams.Store(info.SSRC, stream)
+
+	r.mu.Lock()
+	// TODO(jeremija) what if BindRTCPWriter was not called here? Current code
+	// would panic. I think we need to bail out either by returning an error or
+	// just silently return the writer without intercepting (meh).
+	sCtx := r.sessions[info.SessionID]
+	r.mu.Unlock()
+
+	sCtx.streams.Store(info.SSRC, stream)
 
 	return interceptor.RTPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
 		i, attr, err := reader.Read(b, a)
@@ -133,12 +156,23 @@ func (r *ReceiverInterceptor) BindRemoteStream(info *interceptor.StreamInfo, rea
 
 // UnbindLocalStream is called when the Stream is removed. It can be used to clean up any data related to that track.
 func (r *ReceiverInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
-	r.streams.Delete(info.SSRC)
+	r.mu.Lock()
+	if sCtx, ok := r.sessions[info.SessionID]; ok {
+		sCtx.streams.Delete(info.SSRC)
+	}
+	r.mu.Unlock()
 }
 
 // BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
 // change in the future. The returned method will be called once per packet batch.
-func (r *ReceiverInterceptor) BindRTCPReader(reader interceptor.RTCPReader) interceptor.RTCPReader {
+func (r *ReceiverInterceptor) BindRTCPReader(sessionID interceptor.SessionID, reader interceptor.RTCPReader) interceptor.RTCPReader {
+	r.mu.Lock()
+	// TODO(jeremija) what if BindRTCPWriter was not called before? Current code
+	// would panic. I think we need to bail out either by returning an error or
+	// just silently return the writer without intercepting (meh).
+	sCtx := r.sessions[sessionID]
+	r.mu.Unlock()
+
 	return interceptor.RTCPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
 		i, attr, err := reader.Read(b, a)
 		if err != nil {
@@ -152,7 +186,7 @@ func (r *ReceiverInterceptor) BindRTCPReader(reader interceptor.RTCPReader) inte
 
 		for _, pkt := range pkts {
 			if sr, ok := (pkt).(*rtcp.SenderReport); ok {
-				value, ok := r.streams.Load(sr.SSRC)
+				value, ok := sCtx.streams.Load(sr.SSRC)
 				if !ok {
 					continue
 				}

--- a/pkg/report/receiver_interceptor_test.go
+++ b/pkg/report/receiver_interceptor_test.go
@@ -12,7 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure ReceiverInterceptor satisfies the Interceptor interface.
+var _ interceptor.Interceptor = &ReceiverInterceptor{}
+
 func TestReceiverInterceptor(t *testing.T) {
+	sessionID := interceptor.SessionID("test")
+
 	t.Run("before any packet", func(t *testing.T) {
 		mt := test.MockTime{}
 		i, err := NewReceiverInterceptor(
@@ -23,11 +28,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		pkts := <-stream.WrittenRTCP()
@@ -58,11 +64,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		for i := 0; i < 10; i++ {
@@ -97,11 +104,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		for i := 0; i < 10; i++ {
@@ -147,11 +155,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{
@@ -188,11 +197,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{
@@ -255,11 +265,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{
@@ -296,11 +307,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		for _, seqNum := range []uint16{0x01, 0x03, 0x02, 0x04} {
@@ -335,11 +347,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		mt.SetNow(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
@@ -381,11 +394,12 @@ func TestReceiverInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		mt.SetNow(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))

--- a/pkg/report/sender_interceptor_test.go
+++ b/pkg/report/sender_interceptor_test.go
@@ -12,7 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure SenderInterceptor satisfies the Interceptor interface.
+var _ interceptor.Interceptor = &SenderInterceptor{}
+
 func TestSenderInterceptor(t *testing.T) {
+	sessionID := interceptor.SessionID("test")
+
 	t.Run("before any packet", func(t *testing.T) {
 		mt := &test.MockTime{}
 		i, err := NewSenderInterceptor(
@@ -23,11 +28,12 @@ func TestSenderInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		mt.SetNow(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
@@ -54,11 +60,12 @@ func TestSenderInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
+			SessionID: sessionID,
 			SSRC:      123456,
 			ClockRate: 90000,
 		}, i)
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.Close(sessionID))
 		}()
 
 		for i := 0; i < 10; i++ {

--- a/registry.go
+++ b/registry.go
@@ -2,19 +2,27 @@ package interceptor
 
 // Registry is a collector for interceptors.
 type Registry struct {
-	interceptors []Interceptor
+	factories []Factory
 }
 
-// Add adds a new Interceptor to the registry.
+// Add adds a new Interceptor to the registry. It will be wrapped by a
+// SharedFactory.
 func (i *Registry) Add(icpr Interceptor) {
-	i.interceptors = append(i.interceptors, icpr)
+	i.factories = append(i.factories, NewSharedFactory(icpr))
+}
+
+// AddFactory adds a Factory to the registry.
+func (i *Registry) AddFactory(factory Factory) {
+	i.factories = append(i.factories, factory)
 }
 
 // Build constructs a single Interceptor from a InterceptorRegistry
-func (i *Registry) Build() Interceptor {
-	if len(i.interceptors) == 0 {
-		return &NoOp{}
+// TODO(jeremija) If we always expect to have a RTCPWriter bound, does it make
+// sense to expect the writer to be passed through here?
+func (i *Registry) Build(sessionID SessionID) (Interceptor, error) {
+	if len(i.factories) == 0 {
+		return &NoOp{}, nil
 	}
 
-	return NewChain(i.interceptors)
+	return NewChainFromFactories(i.factories, sessionID)
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,77 @@
+package interceptor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockInterceptor struct {
+	*NoOp
+	sessions sessions
+}
+
+type sessions map[SessionID]struct{}
+
+func newMockInterceptor(sess sessions) *mockInterceptor {
+	return &mockInterceptor{
+		NoOp:     &NoOp{},
+		sessions: sess,
+	}
+}
+
+func (m *mockInterceptor) BindRTCPWriter(sessionID SessionID, writer RTCPWriter) RTCPWriter {
+	m.sessions[sessionID] = struct{}{}
+
+	return writer
+}
+
+func TestRegistry_Add_Build(t *testing.T) {
+	r := Registry{}
+	sess := sessions{}
+	i := newMockInterceptor(sess)
+
+	r.Add(i)
+
+	i1, err := r.Build("a")
+	require.NoError(t, err)
+
+	i2, err := r.Build("b")
+	require.NoError(t, err)
+
+	i1.BindRTCPWriter("a", nil)
+	i2.BindRTCPWriter("b", nil)
+
+	assert.Contains(t, sess, SessionID("a"), "expected session 'a'")
+	assert.Contains(t, sess, SessionID("b"), "expected session 'b'")
+}
+
+func TestRegistry_AddFactory_Build(t *testing.T) {
+	r := Registry{}
+
+	interceptorsBySession := map[SessionID]*mockInterceptor{}
+
+	factory := FactoryFunc(func(sessionID SessionID) (Interceptor, error) {
+		sess := sessions{}
+		i := newMockInterceptor(sess)
+		interceptorsBySession[sessionID] = i
+		return i, nil
+	})
+
+	r.AddFactory(factory)
+
+	i1, err := r.Build("a")
+	require.NoError(t, err)
+
+	i2, err := r.Build("b")
+	require.NoError(t, err)
+
+	i1.BindRTCPWriter("a", nil)
+	i2.BindRTCPWriter("b", nil)
+
+	assert.Contains(t, interceptorsBySession, SessionID("a"), "expected session 'a'")
+	assert.Contains(t, interceptorsBySession, SessionID("b"), "expected session 'b'")
+	assert.NotEqual(t, interceptorsBySession["a"], interceptorsBySession["b"],
+		"expected two separate interceptor instances")
+}

--- a/streaminfo.go
+++ b/streaminfo.go
@@ -9,6 +9,7 @@ type RTPHeaderExtension struct {
 // StreamInfo is the Context passed when a StreamLocal or StreamRemote has been Binded or Unbinded
 type StreamInfo struct {
 	ID                  string
+	SessionID           SessionID
 	Attributes          Attributes
 	SSRC                uint32
 	PayloadType         uint8


### PR DESCRIPTION
Closes #37. This commit addresses the changes discussed [here][1].

I added `SessionID` to all interceptor methods and ensured that the existing interceptors can be shared by different `PeerConnection`s.

I defined an `interceptor.Factory` following AtWat's suggestion. It took a while for this to click for me: I didn't realize that the `interceptor.Registry` contained already prebuilt interceptors. I like the idea of a `Factory` better than implementing `Copy`. I added the `interceptor.Registry.AddFactory` method and modified the internals a little. The new `interceptor.NewChainFromFactories` will now be called from the `Registry`.

The `interceptor.SharedFactory` allows us to easily keep the current behavior with existing interceptors.

I left a number of **TODO**s which are the main reason the build is currently failing. The main points are:

1. I think binding anything before calling `BindRTCPWriter` should be an error, because otherwise it becomes difficult to track state (e.g. if we've started a write loop). But I did not want to add an error return value to all methods before discussing it.

   If we do decide that calling `BindRTCPWriter` is the first step, then I think it would make sense to pass `RTCPWriter` as an argument to `interceptor.Registry.Build`?

2. We could modify the interceptors to only have a single `loop` goroutine which would go through all SSRCs for all bound sessions at once, but I'm not sure what's the best way to concurrently handle RTCP writes - I'm sure we wouldn't want a hanging RTCPWrite to slow down any other processing or writes.

   I also don't think that spinning up an unbounded number of goroutines just to do these writes is a good idea, so I'm not sure how to processed. I'm open to suggestions.

   Maybe this shouldn't be a part of this change, but it's something to think about.

[1]: https://github.com/pion/webrtc/issues/1749
