### PR TITLE
Naive PLI implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/sean-der) - *Original Author*
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Alessandro Ros](https://github.com/aler9)
+* [Antoine Baché](https://github.com/Antonito)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/pli/generator_interceptor.go
+++ b/pkg/pli/generator_interceptor.go
@@ -1,0 +1,146 @@
+package pli
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/logging"
+	"github.com/pion/rtcp"
+)
+
+// GeneratorInterceptor interceptor sends PLI packets.
+// Implements PLI in a naive way: sends a PLI for each new track that support PLI, periodically.
+type GeneratorInterceptor struct {
+	interceptor.NoOp
+
+	interval           time.Duration
+	streams            sync.Map
+	immediatePLINeeded chan []uint32
+
+	log logging.LeveledLogger
+	m   sync.Mutex
+	wg  sync.WaitGroup
+
+	close chan struct{}
+}
+
+// NewGeneratorInterceptor returns a new GeneratorInterceptor interceptor.
+func NewGeneratorInterceptor(opts ...GeneratorOption) (*GeneratorInterceptor, error) {
+	r := &GeneratorInterceptor{
+		interval:           3 * time.Second,
+		log:                logging.NewDefaultLoggerFactory().NewLogger("pli_generator"),
+		immediatePLINeeded: make(chan []uint32, 1),
+		close:              make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		if err := opt(r); err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
+}
+
+func (r *GeneratorInterceptor) isClosed() bool {
+	select {
+	case <-r.close:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close closes the interceptor.
+func (r *GeneratorInterceptor) Close() error {
+	defer r.wg.Wait()
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if !r.isClosed() {
+		close(r.close)
+	}
+
+	return nil
+}
+
+// BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
+// will be called once per packet batch.
+func (r *GeneratorInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interceptor.RTCPWriter {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if r.isClosed() {
+		return writer
+	}
+
+	r.wg.Add(1)
+
+	go r.loop(writer)
+
+	return writer
+}
+
+func (r *GeneratorInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case ssrcs := <-r.immediatePLINeeded:
+			pkts := []rtcp.Packet{}
+
+			for _, ssrc := range ssrcs {
+				pkts = append(pkts, &rtcp.PictureLossIndication{MediaSSRC: ssrc})
+			}
+
+			if _, err := rtcpWriter.Write(pkts, interceptor.Attributes{}); err != nil {
+				r.log.Warnf("failed sending: %+v", err)
+			}
+
+		case <-ticker.C:
+			r.streams.Range(func(key, value interface{}) bool {
+				pkts := []rtcp.Packet{&rtcp.PictureLossIndication{
+					MediaSSRC: key.(uint32),
+				}}
+
+				if _, err := rtcpWriter.Write(pkts, interceptor.Attributes{}); err != nil {
+					r.log.Warnf("failed sending: %+v", err)
+				}
+
+				return true
+			})
+
+		case <-r.close:
+			return
+		}
+	}
+}
+
+// BindRemoteStream lets you modify any incoming RTP packets. It is called once for per RemoteStream. The returned method
+// will be called once per rtp packet.
+func (r *GeneratorInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reader interceptor.RTPReader) interceptor.RTPReader {
+	if !streamSupportPli(info) {
+		return reader
+	}
+
+	r.streams.Store(info.SSRC, nil)
+	// New streams need to receive a PLI as soon as possible.
+	r.immediatePLINeeded <- []uint32{info.SSRC}
+
+	return reader
+}
+
+// UnbindLocalStream is called when the Stream is removed. It can be used to clean up any data related to that track.
+func (r *GeneratorInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
+	r.streams.Delete(info.SSRC)
+}
+
+// BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
+// change in the future. The returned method will be called once per packet batch.
+func (r *GeneratorInterceptor) BindRTCPReader(reader interceptor.RTCPReader) interceptor.RTCPReader {
+	return reader
+}

--- a/pkg/pli/generator_interceptor_test.go
+++ b/pkg/pli/generator_interceptor_test.go
@@ -1,0 +1,84 @@
+package pli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/test"
+	"github.com/pion/logging"
+	"github.com/pion/rtcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPLIGeneratorInterceptor_Unsupported(t *testing.T) {
+	i, err := NewGeneratorInterceptor(
+		GeneratorInterval(time.Millisecond*10),
+		GeneratorLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
+	)
+	assert.Nil(t, err)
+
+	streamSSRC := uint32(123456)
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SSRC:     streamSSRC,
+		MimeType: "video/h264",
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	timeout := time.NewTimer(100 * time.Millisecond)
+	defer timeout.Stop()
+	select {
+	case <-timeout.C:
+		return
+	case <-stream.WrittenRTCP():
+		assert.FailNow(t, "should not receive any PIL")
+	}
+}
+
+func TestPLIGeneratorInterceptor(t *testing.T) {
+	i, err := NewGeneratorInterceptor(
+		GeneratorInterval(time.Second*1),
+		GeneratorLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
+	)
+	assert.Nil(t, err)
+
+	streamSSRC := uint32(123456)
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SSRC:      streamSSRC,
+		ClockRate: 90000,
+		MimeType:  "video/h264",
+		RTCPFeedback: []interceptor.RTCPFeedback{
+			{Type: "nack", Parameter: "pli"},
+		},
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	pkts := <-stream.WrittenRTCP()
+	assert.Equal(t, len(pkts), 1)
+	sr, ok := pkts[0].(*rtcp.PictureLossIndication)
+	assert.True(t, ok)
+	assert.Equal(t, &rtcp.PictureLossIndication{MediaSSRC: streamSSRC}, sr)
+
+	// Should not have another packet immediately...
+	func() {
+		timeout := time.NewTimer(100 * time.Millisecond)
+		defer timeout.Stop()
+		select {
+		case <-timeout.C:
+			return
+		case <-stream.WrittenRTCP():
+			assert.FailNow(t, "should not receive any PIL")
+		}
+	}()
+
+	// ... but should receive one 1sec later.
+	pkts = <-stream.WrittenRTCP()
+	assert.Equal(t, len(pkts), 1)
+	sr, ok = pkts[0].(*rtcp.PictureLossIndication)
+	assert.True(t, ok)
+	assert.Equal(t, &rtcp.PictureLossIndication{MediaSSRC: streamSSRC}, sr)
+}

--- a/pkg/pli/generator_option.go
+++ b/pkg/pli/generator_option.go
@@ -1,0 +1,26 @@
+package pli
+
+import (
+	"time"
+
+	"github.com/pion/logging"
+)
+
+// GeneratorOption can be used to configure GeneratorInterceptor.
+type GeneratorOption func(r *GeneratorInterceptor) error
+
+// GeneratorLog sets a logger for the interceptor.
+func GeneratorLog(log logging.LeveledLogger) GeneratorOption {
+	return func(r *GeneratorInterceptor) error {
+		r.log = log
+		return nil
+	}
+}
+
+// GeneratorInterval sets send interval for the interceptor.
+func GeneratorInterval(interval time.Duration) GeneratorOption {
+	return func(r *GeneratorInterceptor) error {
+		r.interval = interval
+		return nil
+	}
+}

--- a/pkg/pli/pli.go
+++ b/pkg/pli/pli.go
@@ -1,0 +1,14 @@
+// Package pli provides interceptors to implement Picture Loss Indication mechanism.
+package pli
+
+import "github.com/pion/interceptor"
+
+func streamSupportPli(info *interceptor.StreamInfo) bool {
+	for _, fb := range info.RTCPFeedback {
+		if fb.Type == "nack" && fb.Parameter == "pli" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR implements a naive PLI Generator Interceptor.

The Naive PLI Generator sends a PLI packet for each new track that supports PLI, and then keep sending packets at a constant interval (defaults to 3sec).

The original motivation is to provide a easy way to have a very basic & inefficient but working implementation of PLI – and eventually replace PLI loops in `pion/webrtc/examples`:

```go
// Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
go func() {
	ticker := time.NewTicker(time.Second * 2)
	for range ticker.C {
		if rtcpErr := peerConnection.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}}); rtcpErr != nil {
			fmt.Println(rtcpErr)
		}
	}
}()
```