### PR TITLE
Race fix

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,5 +7,6 @@ Adam Kiss <masterada@gmail.com>
 adamroach <adam@nostrum.com>
 aler9 <46489434+aler9@users.noreply.github.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
+Jonathan Müller <jonathan@fotokite.com>
 Mathis Engelbart <mathis.engelbart@gmail.com>
 Sean DuBois <sean@siobud.com>

--- a/pkg/nack/send_buffer_test.go
+++ b/pkg/nack/send_buffer_test.go
@@ -62,3 +62,33 @@ func TestSendBuffer(t *testing.T) {
 		assertNOTGet(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
 	}
 }
+
+// this test is only useful when being run with the race detector, it won't fail otherwise:
+//
+//     go test -race ./pkg/nack/
+func TestSendBuffer_Race(t *testing.T) {
+	for _, start := range []uint16{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 511, 512, 513, 32767, 32768, 32769, 65527, 65528, 65529, 65530, 65531, 65532, 65533, 65534, 65535} {
+		start := start
+
+		sb, err := newSendBuffer(8)
+		assert.NoError(t, err)
+
+		add := func(nums ...uint16) {
+			for _, n := range nums {
+				seq := start + n
+				sb.add(&rtp.Packet{Header: rtp.Header{SequenceNumber: seq}})
+			}
+		}
+
+		get := func(nums ...uint16) {
+			t.Helper()
+			for _, n := range nums {
+				seq := start + n
+				sb.get(seq)
+			}
+		}
+
+		go add(0, 1, 2, 3, 4, 5, 6, 7)
+		go get(0, 1, 2, 3, 4, 5, 6, 7)
+	}
+}


### PR DESCRIPTION
#### Description

This fixes the race condition described in #28, and also adds 2 regression tests for the fix.

Can be verified by reverting the last commit, and running `go test -race ./pkg/nack/`.

AFAIK your CI is already running tests with race detection, so no changes needed there.

#### Reference issue
Fixes #28 