### PR TITLE
Lengthen some acronyms

### DIFF
--- a/pkg/twcc/header_extension.go
+++ b/pkg/twcc/header_extension.go
@@ -34,9 +34,9 @@ func (h *HeaderExtensionInterceptor) BindLocalStream(info *interceptor.StreamInf
 		return writer
 	}
 	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
-		seqNr := atomic.AddUint32(&h.nextSequenceNr, 1) - 1
+		sequenceNumber := atomic.AddUint32(&h.nextSequenceNr, 1) - 1
 
-		tcc, err := (&rtp.TransportCCExtension{TransportSequence: uint16(seqNr)}).Marshal()
+		tcc, err := (&rtp.TransportCCExtension{TransportSequence: uint16(sequenceNumber)}).Marshal()
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/twcc/sender_interceptor.go
+++ b/pkg/twcc/sender_interceptor.go
@@ -78,10 +78,10 @@ func (s *SenderInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interc
 }
 
 type packet struct {
-	hdr   *rtp.Header
-	seqNr uint16
-	ts    int64
-	ssrc  uint32
+	hdr            *rtp.Header
+	sequenceNumber uint16
+	arrivalTime    int64
+	ssrc           uint32
 }
 
 // BindRemoteStream lets you modify any incoming RTP packets. It is called once for per RemoteStream. The returned method
@@ -115,10 +115,10 @@ func (s *SenderInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reade
 			}
 
 			s.packetChan <- packet{
-				hdr:   &p.Header,
-				seqNr: tccExt.TransportSequence,
-				ts:    time.Now().UnixNano(),
-				ssrc:  info.SSRC,
+				hdr:            &p.Header,
+				sequenceNumber: tccExt.TransportSequence,
+				arrivalTime:    time.Now().UnixNano(),
+				ssrc:           info.SSRC,
 			}
 		}
 
@@ -158,7 +158,7 @@ func (s *SenderInterceptor) loop(w interceptor.RTCPWriter) {
 		case <-s.close:
 			return
 		case p := <-s.packetChan:
-			s.recorder.Record(p.ssrc, p.seqNr, p.ts/1e6) // ns -> ms: divide by 1e6
+			s.recorder.Record(p.ssrc, p.sequenceNumber, p.arrivalTime/1e6) // ns -> ms: divide by 1e6
 
 		case <-ticker.C:
 			// build and send twcc

--- a/pkg/twcc/sender_interceptor_test.go
+++ b/pkg/twcc/sender_interceptor_test.go
@@ -138,7 +138,7 @@ func TestSenderInterceptor(t *testing.T) {
 			assert.NoError(t, stream.Close())
 		}()
 
-		seqNrToDelay := map[int]int{
+		sequenceNumberToDelay := map[int]int{
 			0:  0,
 			1:  10,
 			4:  100,
@@ -148,7 +148,7 @@ func TestSenderInterceptor(t *testing.T) {
 			30: 300,
 		}
 		for _, i := range []int{0, 1, 4, 8, 9, 10, 30} {
-			d := seqNrToDelay[i]
+			d := sequenceNumberToDelay[i]
 			time.Sleep(time.Duration(d) * time.Millisecond)
 
 			hdr := rtp.Header{}

--- a/pkg/twcc/twcc_test.go
+++ b/pkg/twcc/twcc_test.go
@@ -167,12 +167,12 @@ func Test_feedback(t *testing.T) {
 		got := f.addReceived(1, 1023*1000)
 
 		assert.True(t, got)
-		assert.Equal(t, uint16(2), f.nextSeqNr)
+		assert.Equal(t, uint16(2), f.nextSequenceNumber)
 		assert.Equal(t, int64(15), f.refTimestamp64MS)
 
 		got = f.addReceived(4, 1086*1000)
 		assert.True(t, got)
-		assert.Equal(t, uint16(5), f.nextSeqNr)
+		assert.Equal(t, uint16(5), f.nextSequenceNumber)
 		assert.Equal(t, int64(15), f.refTimestamp64MS)
 
 		assert.True(t, f.lastChunk.hasDifferentTypes)
@@ -315,10 +315,10 @@ func Test_feedback(t *testing.T) {
 
 	t.Run("get RTCP", func(t *testing.T) {
 		testcases := []struct {
-			arrivalTS     int64
-			seqNr         uint16
-			wantRefTime   uint32
-			wantBaseSeqNr uint16
+			arrivalTS              int64
+			sequenceNumber         uint16
+			wantRefTime            uint32
+			wantBaseSequenceNumber uint16
 		}{
 			{320, 1, 5, 1},
 			{1000, 2, 15, 2},
@@ -328,11 +328,11 @@ func Test_feedback(t *testing.T) {
 
 			t.Run("set correct base seq and time", func(t *testing.T) {
 				f := newFeedback(0, 0, 0)
-				f.setBase(tt.seqNr, tt.arrivalTS*1000)
+				f.setBase(tt.sequenceNumber, tt.arrivalTS*1000)
 
 				got := f.getRTCP()
 				assert.Equal(t, tt.wantRefTime, got.ReferenceTime)
-				assert.Equal(t, tt.wantBaseSeqNr, got.BaseSequenceNumber)
+				assert.Equal(t, tt.wantBaseSequenceNumber, got.BaseSequenceNumber)
 			})
 		}
 	})


### PR DESCRIPTION
`seqNr` isn't one I commonly see. `arrivalTime` just to match the RFC a bit more. 

Feel free to push back @mengelbart if you disagree! I am just confirming that everything works before merging pion/webrtc