### PR TITLE
Use proper units with rtcp TWCC packets

### DIFF
--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -2,6 +2,7 @@
 package twcc
 
 import (
+	"math"
 	"sort"
 
 	"github.com/pion/rtcp"
@@ -136,8 +137,7 @@ func (f *feedback) getRTCP() *rtcp.TransportLayerCC {
 func (f *feedback) addReceived(sequenceNumber uint16, timestampUS int64) bool {
 	deltaUS := timestampUS - f.lastTimestampUS
 	delta250US := deltaUS / 250
-	delta16 := uint16(delta250US)
-	if int64(delta16) != delta250US { // delta doesn't fit into 16 bit, need to create new packet
+	if delta250US < math.MinInt16 || delta250US > math.MaxInt16 { // delta doesn't fit into 16 bit, need to create new packet
 		return false
 	}
 
@@ -165,7 +165,7 @@ func (f *feedback) addReceived(sequenceNumber uint16, timestampUS int64) bool {
 	f.lastChunk.add(recvDelta)
 	f.deltas = append(f.deltas, &rtcp.RecvDelta{
 		Type:  recvDelta,
-		Delta: delta250US,
+		Delta: deltaUS,
 	})
 	f.lastTimestampUS = timestampUS
 	f.sequenceNumberCount++

--- a/pkg/twcc/twcc_test.go
+++ b/pkg/twcc/twcc_test.go
@@ -223,15 +223,15 @@ func Test_feedback(t *testing.T) {
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0200,
+				Delta: 0x0200 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0100,
+				Delta: 0x0100 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0400,
+				Delta: 0x0400 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 		}
 		assert.Equal(t, len(expectedDeltas), len(pkt.RecvDeltas))
@@ -296,15 +296,15 @@ func Test_feedback(t *testing.T) {
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0200,
+				Delta: 0x0200 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0100,
+				Delta: 0x0100 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 			{
 				Type:  rtcp.TypeTCCPacketReceivedLargeDelta,
-				Delta: 0x0400,
+				Delta: 0x0400 * rtcp.TypeTCCDeltaScaleFactor,
 			},
 		}
 		assert.Equal(t, len(expectedDeltas), len(pkt.RecvDeltas))
@@ -407,13 +407,13 @@ func TestBuildFeedbackPacket(t *testing.T) {
 		},
 		RecvDeltas: []*rtcp.RecvDelta{
 			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 0},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedLargeDelta, Delta: 256},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedLargeDelta, Delta: rtcp.TypeTCCDeltaScaleFactor * 256},
 		},
 	}, rtcpPackets[0].(*rtcp.TransportLayerCC))
 	marshalAll(t, rtcpPackets)
@@ -470,10 +470,10 @@ func TestBuildFeedbackPacket_Rolling(t *testing.T) {
 		},
 		RecvDeltas: []*rtcp.RecvDelta{
 			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 0},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
-			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: 1},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
+			{Type: rtcp.TypeTCCPacketReceivedSmallDelta, Delta: rtcp.TypeTCCDeltaScaleFactor},
 		},
 	}, rtcpPackets[0].(*rtcp.TransportLayerCC))
 	marshalAll(t, rtcpPackets)


### PR DESCRIPTION
pion/rtcp expects input to be in Nanoseconds, and does n / 250 during
the marshal.

Resolves #61