### PR TITLE
Add InterceptorFactory

### DIFF
--- a/examples/nack/main.go
+++ b/examples/nack/main.go
@@ -35,7 +35,12 @@ func receiveRoutine() {
 	}
 
 	// Create NACK Generator
-	generator, err := nack.NewGeneratorInterceptor()
+	generatorFactory, err := nack.NewGeneratorInterceptor()
+	if err != nil {
+		panic(err)
+	}
+
+	generator, err := generatorFactory.NewInterceptor("")
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +97,12 @@ func sendRoutine() {
 	}
 
 	// Create NACK Responder
-	responder, err := nack.NewResponderInterceptor()
+	responderFactory, err := nack.NewResponderInterceptor()
+	if err != nil {
+		panic(err)
+	}
+
+	responder, err := responderFactory.NewInterceptor("")
 	if err != nil {
 		panic(err)
 	}

--- a/interceptor.go
+++ b/interceptor.go
@@ -9,6 +9,11 @@ import (
 	"github.com/pion/rtp"
 )
 
+// Factory provides an interface for constructing interceptors
+type Factory interface {
+	NewInterceptor(id string) (Interceptor, error)
+}
+
 // Interceptor can be used to add functionality to you PeerConnections by modifying any incoming/outgoing rtp/rtcp
 // packets, or sending your own packets as needed.
 type Interceptor interface {

--- a/pkg/mock/factory.go
+++ b/pkg/mock/factory.go
@@ -1,0 +1,13 @@
+package mock
+
+import "github.com/pion/interceptor"
+
+// Factory is a mock Factory for testing.
+type Factory struct {
+	NewInterceptorFn func(id string) (interceptor.Interceptor, error)
+}
+
+// NewInterceptor implements Interceptor
+func (f *Factory) NewInterceptor(id string) (interceptor.Interceptor, error) {
+	return f.NewInterceptorFn(id)
+}

--- a/pkg/nack/generator_interceptor_test.go
+++ b/pkg/nack/generator_interceptor_test.go
@@ -14,12 +14,15 @@ import (
 
 func TestGeneratorInterceptor(t *testing.T) {
 	const interval = time.Millisecond * 10
-	i, err := NewGeneratorInterceptor(
+	f, err := NewGeneratorInterceptor(
 		GeneratorSize(64),
 		GeneratorSkipLastN(2),
 		GeneratorInterval(interval),
 		GeneratorLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 	)
+	assert.NoError(t, err)
+
+	i, err := f.NewInterceptor("")
 	assert.NoError(t, err)
 
 	stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -65,6 +68,8 @@ func TestGeneratorInterceptor(t *testing.T) {
 }
 
 func TestGeneratorInterceptor_InvalidSize(t *testing.T) {
-	_, err := NewGeneratorInterceptor(GeneratorSize(5))
+	f, _ := NewGeneratorInterceptor(GeneratorSize(5))
+
+	_, err := f.NewInterceptor("")
 	assert.Error(t, err, ErrInvalidSize)
 }

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -9,6 +9,32 @@ import (
 	"github.com/pion/rtp"
 )
 
+// ResponderInterceptorFactory is a interceptor.Factory for a ResponderInterceptor
+type ResponderInterceptorFactory struct {
+	opts []ResponderOption
+}
+
+// NewInterceptor constructs a new ResponderInterceptor
+func (r *ResponderInterceptorFactory) NewInterceptor(id string) (interceptor.Interceptor, error) {
+	i := &ResponderInterceptor{
+		size:    8192,
+		log:     logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
+		streams: map[uint32]*localStream{},
+	}
+
+	for _, opt := range r.opts {
+		if err := opt(i); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := newSendBuffer(i.size); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
 // ResponderInterceptor responds to nack feedback messages
 type ResponderInterceptor struct {
 	interceptor.NoOp
@@ -24,25 +50,9 @@ type localStream struct {
 	rtpWriter  interceptor.RTPWriter
 }
 
-// NewResponderInterceptor returns a new ResponderInterceptor interceptor
-func NewResponderInterceptor(opts ...ResponderOption) (*ResponderInterceptor, error) {
-	r := &ResponderInterceptor{
-		size:    8192,
-		log:     logging.NewDefaultLoggerFactory().NewLogger("nack_responder"),
-		streams: map[uint32]*localStream{},
-	}
-
-	for _, opt := range opts {
-		if err := opt(r); err != nil {
-			return nil, err
-		}
-	}
-
-	if _, err := newSendBuffer(r.size); err != nil {
-		return nil, err
-	}
-
-	return r, nil
+// NewResponderInterceptor returns a new ResponderInterceptorFactor
+func NewResponderInterceptor(opts ...ResponderOption) (*ResponderInterceptorFactory, error) {
+	return &ResponderInterceptorFactory{opts}, nil
 }
 
 // BindRTCPReader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might

--- a/pkg/nack/responder_interceptor_test.go
+++ b/pkg/nack/responder_interceptor_test.go
@@ -13,10 +13,13 @@ import (
 )
 
 func TestResponderInterceptor(t *testing.T) {
-	i, err := NewResponderInterceptor(
+	f, err := NewResponderInterceptor(
 		ResponderSize(8),
 		ResponderLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 	)
+	assert.NoError(t, err)
+
+	i, err := f.NewInterceptor("")
 	assert.NoError(t, err)
 
 	stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -66,7 +69,9 @@ func TestResponderInterceptor(t *testing.T) {
 }
 
 func TestResponderInterceptor_InvalidSize(t *testing.T) {
-	_, err := NewResponderInterceptor(ResponderSize(5))
+	f, _ := NewResponderInterceptor(ResponderSize(5))
+
+	_, err := f.NewInterceptor("")
 	assert.Error(t, err, ErrInvalidSize)
 }
 
@@ -74,10 +79,13 @@ func TestResponderInterceptor_InvalidSize(t *testing.T) {
 //
 //     go test -race ./pkg/nack/
 func TestResponderInterceptor_Race(t *testing.T) {
-	i, err := NewResponderInterceptor(
+	f, err := NewResponderInterceptor(
 		ResponderSize(32768),
 		ResponderLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 	)
+	assert.NoError(t, err)
+
+	i, err := f.NewInterceptor("")
 	assert.NoError(t, err)
 
 	stream := test.NewMockStream(&interceptor.StreamInfo{

--- a/pkg/report/receiver_interceptor_test.go
+++ b/pkg/report/receiver_interceptor_test.go
@@ -15,11 +15,14 @@ import (
 func TestReceiverInterceptor(t *testing.T) {
 	t.Run("before any packet", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -50,11 +53,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("after RTP packets", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -89,11 +95,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("after RTP and RTCP packets", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -139,11 +148,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("overflow", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -180,11 +192,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("packet loss", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -247,11 +262,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("overflow and packet loss", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -288,11 +306,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("reordered packets", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -327,11 +348,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("jitter", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -373,11 +397,14 @@ func TestReceiverInterceptor(t *testing.T) {
 
 	t.Run("delay", func(t *testing.T) {
 		mt := test.MockTime{}
-		i, err := NewReceiverInterceptor(
+		f, err := NewReceiverInterceptor(
 			ReceiverInterval(time.Millisecond*50),
 			ReceiverLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			ReceiverNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{

--- a/pkg/report/sender_interceptor_test.go
+++ b/pkg/report/sender_interceptor_test.go
@@ -15,11 +15,14 @@ import (
 func TestSenderInterceptor(t *testing.T) {
 	t.Run("before any packet", func(t *testing.T) {
 		mt := &test.MockTime{}
-		i, err := NewSenderInterceptor(
+		f, err := NewSenderInterceptor(
 			SenderInterval(time.Millisecond*50),
 			SenderLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			SenderNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{
@@ -46,11 +49,14 @@ func TestSenderInterceptor(t *testing.T) {
 
 	t.Run("after RTP packets", func(t *testing.T) {
 		mt := &test.MockTime{}
-		i, err := NewSenderInterceptor(
+		f, err := NewSenderInterceptor(
 			SenderInterval(time.Millisecond*50),
 			SenderLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 			SenderNow(mt.Now),
 		)
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{

--- a/pkg/twcc/header_extension_interceptor.go
+++ b/pkg/twcc/header_extension_interceptor.go
@@ -7,15 +7,24 @@ import (
 	"github.com/pion/rtp"
 )
 
+// HeaderExtensionInterceptorFactory is a interceptor.Factory for a HeaderExtensionInterceptor
+type HeaderExtensionInterceptorFactory struct {
+}
+
+// NewInterceptor constructs a new HeaderExtensionInterceptor
+func (h *HeaderExtensionInterceptorFactory) NewInterceptor(id string) (interceptor.Interceptor, error) {
+	return &HeaderExtensionInterceptor{}, nil
+}
+
+// NewHeaderExtensionInterceptor returns a HeaderExtensionInterceptorFactory
+func NewHeaderExtensionInterceptor() (*HeaderExtensionInterceptorFactory, error) {
+	return &HeaderExtensionInterceptorFactory{}, nil
+}
+
 // HeaderExtensionInterceptor adds transport wide sequence numbers as header extension to each RTP packet
 type HeaderExtensionInterceptor struct {
 	interceptor.NoOp
 	nextSequenceNr uint32
-}
-
-// NewHeaderExtensionInterceptor returns a HeaderExtensionInterceptor
-func NewHeaderExtensionInterceptor() (*HeaderExtensionInterceptor, error) {
-	return &HeaderExtensionInterceptor{}, nil
 }
 
 const transportCCURI = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"

--- a/pkg/twcc/header_extension_interceptor_test.go
+++ b/pkg/twcc/header_extension_interceptor_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestHeaderExtensionInterceptor(t *testing.T) {
 	t.Run("add transport wide cc to each packet", func(t *testing.T) {
-		inter, err := NewHeaderExtensionInterceptor()
+		factory, err := NewHeaderExtensionInterceptor()
+		assert.NoError(t, err)
+
+		inter, err := factory.NewInterceptor("")
 		assert.NoError(t, err)
 
 		pChan := make(chan *rtp.Packet, 10*5)

--- a/pkg/twcc/sender_interceptor_test.go
+++ b/pkg/twcc/sender_interceptor_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestSenderInterceptor(t *testing.T) {
 	t.Run("before any packets", func(t *testing.T) {
-		i, err := NewSenderInterceptor()
+		f, err := NewSenderInterceptor()
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{SSRC: 1, RTPHeaderExtensions: []interceptor.RTPHeaderExtension{
@@ -40,7 +43,10 @@ func TestSenderInterceptor(t *testing.T) {
 	})
 
 	t.Run("after RTP packets", func(t *testing.T) {
-		i, err := NewSenderInterceptor()
+		f, err := NewSenderInterceptor()
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{SSRC: 1, RTPHeaderExtensions: []interceptor.RTPHeaderExtension{
@@ -77,9 +83,10 @@ func TestSenderInterceptor(t *testing.T) {
 	})
 
 	t.Run("different delays between RTP packets", func(t *testing.T) {
-		i, err := NewSenderInterceptor(
-			SendInterval(500 * time.Millisecond),
-		)
+		f, err := NewSenderInterceptor(SendInterval(500 * time.Millisecond))
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{RTPHeaderExtensions: []interceptor.RTPHeaderExtension{
@@ -123,9 +130,10 @@ func TestSenderInterceptor(t *testing.T) {
 	})
 
 	t.Run("packet loss", func(t *testing.T) {
-		i, err := NewSenderInterceptor(
-			SendInterval(2 * time.Second),
-		)
+		f, err := NewSenderInterceptor(SendInterval(2 * time.Second))
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{RTPHeaderExtensions: []interceptor.RTPHeaderExtension{
@@ -201,9 +209,10 @@ func TestSenderInterceptor(t *testing.T) {
 	})
 
 	t.Run("overflow", func(t *testing.T) {
-		i, err := NewSenderInterceptor(
-			SendInterval(2 * time.Second),
-		)
+		f, err := NewSenderInterceptor(SendInterval(2 * time.Second))
+		assert.NoError(t, err)
+
+		i, err := f.NewInterceptor("")
 		assert.NoError(t, err)
 
 		stream := test.NewMockStream(&interceptor.StreamInfo{RTPHeaderExtensions: []interceptor.RTPHeaderExtension{

--- a/registry.go
+++ b/registry.go
@@ -2,19 +2,29 @@ package interceptor
 
 // Registry is a collector for interceptors.
 type Registry struct {
-	interceptors []Interceptor
+	factories []Factory
 }
 
 // Add adds a new Interceptor to the registry.
-func (i *Registry) Add(icpr Interceptor) {
-	i.interceptors = append(i.interceptors, icpr)
+func (r *Registry) Add(f Factory) {
+	r.factories = append(r.factories, f)
 }
 
 // Build constructs a single Interceptor from a InterceptorRegistry
-func (i *Registry) Build() Interceptor {
-	if len(i.interceptors) == 0 {
-		return &NoOp{}
+func (r *Registry) Build(id string) (Interceptor, error) {
+	if len(r.factories) == 0 {
+		return &NoOp{}, nil
 	}
 
-	return NewChain(i.interceptors)
+	interceptors := []Interceptor{}
+	for _, f := range r.factories {
+		i, err := f.NewInterceptor(id)
+		if err != nil {
+			return nil, err
+		}
+
+		interceptors = append(interceptors, i)
+	}
+
+	return NewChain(interceptors), nil
 }


### PR DESCRIPTION
Interceptors are being accidentally misused by users.
The issue is that an Interceptor can be re-used between
multiple PeerConnections. Interceptors were designed to only be
single PeerConnection aware, so state is being corrupted.

Instead we are now going to provide InterceptorFactories. The default
API of pion/webrtc will now be safe to use between PeerConnections.

Relates to pion/webrtc#1956