### PR TITLE
Add GetRTPHeader/GetRTCPHeader to attributes

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -1,0 +1,66 @@
+package interceptor
+
+import (
+	"errors"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+type rtpHeaderKeyType int
+
+const (
+	rtpHeaderKey rtpHeaderKeyType = iota
+	rtcpHeaderKey
+)
+
+var errInvalidHeaderType = errors.New("found invalid header type in attributes map")
+
+// Attributes are a generic key/value store used by interceptors
+type Attributes map[interface{}]interface{}
+
+// Get returns the attribute associated with key.
+func (a Attributes) Get(key interface{}) interface{} {
+	return a[key]
+}
+
+// Set sets the attribute associated with key to the given value.
+func (a Attributes) Set(key interface{}, val interface{}) {
+	a[key] = val
+}
+
+// GetRTPHeader gets the RTP header if present. If the header is not present, it
+// will be unmarshaled from the raw byte slice and stored in the attributes.
+func (a Attributes) GetRTPHeader(raw []byte) (*rtp.Header, error) {
+	if val, ok := a[rtpHeaderKey]; ok {
+		if header, ok := val.(*rtp.Header); ok {
+			return header, nil
+		}
+		return nil, errInvalidHeaderType
+	}
+	header := &rtp.Header{}
+	_, err := header.Unmarshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	a[rtpHeaderKey] = header
+	return header, nil
+}
+
+// GetRTCPHeader gets the RTCP header if present. If the header is not present,
+// it will be unmarshaled from the raw byte slice and stored in the attributes.
+func (a Attributes) GetRTCPHeader(raw []byte) (*rtcp.Header, error) {
+	if val, ok := a[rtcpHeaderKey]; ok {
+		if header, ok := val.(*rtcp.Header); ok {
+			return header, nil
+		}
+		return nil, errInvalidHeaderType
+	}
+	header := &rtcp.Header{}
+	err := header.Unmarshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	a[rtcpHeaderKey] = header
+	return header, nil
+}

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -1,0 +1,144 @@
+package interceptor
+
+import (
+	"testing"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributesGetRTPHeader(t *testing.T) {
+	t.Run("NilHeader", func(t *testing.T) {
+		attributes := Attributes{}
+		_, err := attributes.GetRTPHeader(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("Present", func(t *testing.T) {
+		attributes := Attributes{
+			rtpHeaderKey: &rtp.Header{
+				Version:          0,
+				Padding:          false,
+				Extension:        false,
+				Marker:           false,
+				PayloadType:      0,
+				SequenceNumber:   0,
+				Timestamp:        0,
+				SSRC:             0,
+				CSRC:             []uint32{},
+				ExtensionProfile: 0,
+				Extensions:       nil,
+			},
+		}
+		header, err := attributes.GetRTPHeader(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, attributes[rtpHeaderKey], header)
+	})
+
+	t.Run("NotPresent", func(t *testing.T) {
+		attributes := Attributes{}
+		hdr := &rtp.Header{
+			Version:          0,
+			Padding:          false,
+			Extension:        false,
+			Marker:           false,
+			PayloadType:      0,
+			SequenceNumber:   0,
+			Timestamp:        0,
+			SSRC:             0,
+			CSRC:             []uint32{},
+			ExtensionProfile: 0,
+			Extensions:       nil,
+		}
+		buf, err := hdr.Marshal()
+		assert.NoError(t, err)
+		header, err := attributes.GetRTPHeader(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, hdr, header)
+	})
+
+	t.Run("NotPresentFromFullRTPPacket", func(t *testing.T) {
+		attributes := Attributes{}
+		pkt := &rtp.Packet{Header: rtp.Header{
+			Version:          0,
+			Padding:          false,
+			Extension:        false,
+			Marker:           false,
+			PayloadType:      0,
+			SequenceNumber:   0,
+			Timestamp:        0,
+			SSRC:             0,
+			CSRC:             []uint32{},
+			ExtensionProfile: 0,
+			Extensions:       nil,
+		}, Payload: make([]byte, 1000)}
+		buf, err := pkt.Marshal()
+		assert.NoError(t, err)
+		header, err := attributes.GetRTPHeader(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, &pkt.Header, header)
+	})
+}
+
+func TestAttributesGetRTCPHeader(t *testing.T) {
+	t.Run("NilHeader", func(t *testing.T) {
+		attributes := Attributes{}
+		_, err := attributes.GetRTCPHeader(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("Present", func(t *testing.T) {
+		attributes := Attributes{
+			rtcpHeaderKey: &rtcp.Header{
+				Padding: false,
+				Count:   0,
+				Type:    0,
+				Length:  0,
+			},
+		}
+		header, err := attributes.GetRTCPHeader(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, attributes[rtcpHeaderKey], header)
+	})
+
+	t.Run("NotPresent", func(t *testing.T) {
+		attributes := Attributes{}
+		hdr := &rtcp.Header{
+			Padding: false,
+			Count:   0,
+			Type:    0,
+			Length:  0,
+		}
+		buf, err := hdr.Marshal()
+		assert.NoError(t, err)
+		header, err := attributes.GetRTCPHeader(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, hdr, header)
+	})
+
+	t.Run("NotPresentFromFullRTCPPacket", func(t *testing.T) {
+		attributes := Attributes{}
+		pkt := rtcp.TransportLayerCC{
+			Header: rtcp.Header{
+				Padding: false,
+				Count:   0,
+				Type:    0,
+				Length:  0,
+			},
+			SenderSSRC:         0,
+			MediaSSRC:          0,
+			BaseSequenceNumber: 0,
+			PacketStatusCount:  0,
+			ReferenceTime:      0,
+			FbPktCount:         0,
+			PacketChunks:       []rtcp.PacketStatusChunk{},
+			RecvDeltas:         []*rtcp.RecvDelta{},
+		}
+		buf, err := pkt.Marshal()
+		assert.NoError(t, err)
+		header, err := attributes.GetRTCPHeader(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, &pkt.Header, header)
+	})
+}

--- a/interceptor.go
+++ b/interceptor.go
@@ -67,9 +67,6 @@ type RTCPReader interface {
 	Read([]byte, Attributes) (int, Attributes, error)
 }
 
-// Attributes are a generic key/value store used by interceptors
-type Attributes map[interface{}]interface{}
-
 // RTPWriterFunc is an adapter for RTPWrite interface
 type RTPWriterFunc func(header *rtp.Header, payload []byte, attributes Attributes) (int, error)
 
@@ -100,14 +97,4 @@ func (f RTCPWriterFunc) Write(pkts []rtcp.Packet, attributes Attributes) (int, e
 // Read a batch of rtcp packets
 func (f RTCPReaderFunc) Read(b []byte, a Attributes) (int, Attributes, error) {
 	return f(b, a)
-}
-
-// Get returns the attribute associated with key.
-func (a Attributes) Get(key interface{}) interface{} {
-	return a[key]
-}
-
-// Set sets the attribute associated with key to the given value.
-func (a Attributes) Set(key interface{}, val interface{}) {
-	a[key] = val
 }


### PR DESCRIPTION
Avoids repeated header unmarshalling when multiple interceptors need to access the header.