### PR TITLE
Fix assignment to entry in nil map

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ adamroach <adam@nostrum.com>
 aler9 <46489434+aler9@users.noreply.github.com>
 Antoine Baché <antoine@tenten.app>
 Atsushi Watanabe <atsushi.w@ieee.org>
+boks1971 <raja.gobi@tutanota.com>
 Jonathan Müller <jonathan@fotokite.com>
 Mathis Engelbart <mathis.engelbart@gmail.com>
 Sean DuBois <sean@siobud.com>

--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -95,6 +95,9 @@ func (n *GeneratorInterceptor) BindRemoteStream(info *interceptor.StreamInfo, re
 			return 0, nil, err
 		}
 
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
 		header, err := attr.GetRTPHeader(b[:i])
 		if err != nil {
 			return 0, nil, err

--- a/pkg/nack/receive_log_test.go
+++ b/pkg/nack/receive_log_test.go
@@ -8,6 +8,8 @@ import (
 
 func TestReceivedBuffer(t *testing.T) {
 	for _, start := range []uint16{0, 1, 127, 128, 129, 511, 512, 513, 32767, 32768, 32769, 65407, 65408, 65409, 65534, 65535} {
+		start := start
+
 		t.Run(fmt.Sprintf("StartFrom%d", start), func(t *testing.T) {
 			rl, err := newReceiveLog(128)
 			if err != nil {

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -64,6 +64,9 @@ func (n *ResponderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) int
 			return 0, nil, err
 		}
 
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
 		pkts, err := attr.GetRTCPPackets(b[:i])
 		if err != nil {
 			return 0, nil, err

--- a/pkg/packetdump/receiver_interceptor.go
+++ b/pkg/packetdump/receiver_interceptor.go
@@ -44,10 +44,10 @@ func (r *ReceiverInterceptor) BindRemoteStream(info *interceptor.StreamInfo, rea
 		if err != nil {
 			return 0, nil, err
 		}
+
 		if attr == nil {
 			attr = make(interceptor.Attributes)
 		}
-
 		header, err := attr.GetRTPHeader(bytes)
 		if err != nil {
 			return 0, nil, err
@@ -66,10 +66,10 @@ func (r *ReceiverInterceptor) BindRTCPReader(reader interceptor.RTCPReader) inte
 		if err != nil {
 			return 0, nil, err
 		}
+
 		if attr == nil {
 			attr = make(interceptor.Attributes)
 		}
-
 		pkts, err := attr.GetRTCPPackets(bytes[:i])
 		if err != nil {
 			return 0, nil, err

--- a/pkg/report/receiver_interceptor.go
+++ b/pkg/report/receiver_interceptor.go
@@ -129,6 +129,9 @@ func (r *ReceiverInterceptor) BindRemoteStream(info *interceptor.StreamInfo, rea
 			return 0, nil, err
 		}
 
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
 		header, err := attr.GetRTPHeader(b[:i])
 		if err != nil {
 			return 0, nil, err
@@ -154,6 +157,9 @@ func (r *ReceiverInterceptor) BindRTCPReader(reader interceptor.RTCPReader) inte
 			return 0, nil, err
 		}
 
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
 		pkts, err := attr.GetRTCPPackets(b[:i])
 		if err != nil {
 			return 0, nil, err

--- a/pkg/twcc/header_extension_interceptor.go
+++ b/pkg/twcc/header_extension_interceptor.go
@@ -8,8 +8,7 @@ import (
 )
 
 // HeaderExtensionInterceptorFactory is a interceptor.Factory for a HeaderExtensionInterceptor
-type HeaderExtensionInterceptorFactory struct {
-}
+type HeaderExtensionInterceptorFactory struct{}
 
 // NewInterceptor constructs a new HeaderExtensionInterceptor
 func (h *HeaderExtensionInterceptorFactory) NewInterceptor(id string) (interceptor.Interceptor, error) {

--- a/pkg/twcc/sender_interceptor.go
+++ b/pkg/twcc/sender_interceptor.go
@@ -114,6 +114,10 @@ func (s *SenderInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reade
 		if err != nil {
 			return 0, nil, err
 		}
+
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
 		header, err := attr.GetRTPHeader(buf[:i])
 		if err != nil {
 			return 0, nil, err


### PR DESCRIPTION
We started using attributes to store headers instead of repeatedly
parsing them in every interceptor. This only works if the attributes are
initialized before they are used.
