### PR TITLE
Fixing confusing variable name

### DIFF
--- a/examples/nack/main.go
+++ b/examples/nack/main.go
@@ -112,7 +112,7 @@ func sendRoutine() {
 
 	// Set the interceptor wide RTCP Reader
 	// this is a handle to send NACKs back into the interceptor.
-	rtcpWriter := chain.BindRTCPReader(interceptor.RTCPReaderFunc(func(in []byte, _ interceptor.Attributes) (int, interceptor.Attributes, error) {
+	rtcpReader := chain.BindRTCPReader(interceptor.RTCPReaderFunc(func(in []byte, _ interceptor.Attributes) (int, interceptor.Attributes, error) {
 		return len(in), nil, nil
 	}))
 
@@ -140,7 +140,7 @@ func sendRoutine() {
 
 			log.Println("Received NACK")
 
-			if _, _, err = rtcpWriter.Read(rtcpBuf[:i], nil); err != nil {
+			if _, _, err = rtcpReader.Read(rtcpBuf[:i], nil); err != nil {
 				panic(err)
 			}
 		}


### PR DESCRIPTION
#### Description
Changing `rtcpWriter` to `rtcpReader` to match the actual behavio