### PR TITLE
Fix a bug in Chunk encoding

### DIFF
--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -3,7 +3,6 @@ package twcc
 
 import (
 	"math"
-	"sort"
 
 	"github.com/pion/rtcp"
 )
@@ -78,9 +77,6 @@ func (r *Recorder) BuildFeedbackPacket() []rtcp.Packet {
 		return []rtcp.Packet{feedback.getRTCP()}
 	}
 
-	sort.Slice(r.receivedPackets, func(i, j int) bool {
-		return r.receivedPackets[i].sequenceNumber < r.receivedPackets[j].sequenceNumber
-	})
 	feedback.setBase(uint16(r.receivedPackets[0].sequenceNumber&0xffff), r.receivedPackets[0].arrivalTime)
 
 	var pkts []rtcp.Packet
@@ -133,10 +129,10 @@ func (f *feedback) getRTCP() *rtcp.TransportLayerCC {
 	f.rtcp.PacketStatusCount = f.sequenceNumberCount
 	f.rtcp.ReferenceTime = uint32(f.refTimestamp64MS)
 	f.rtcp.BaseSequenceNumber = f.baseSequenceNumber
-	if len(f.lastChunk.deltas) > 0 {
+	for len(f.lastChunk.deltas) > 0 {
 		f.chunks = append(f.chunks, f.lastChunk.encode())
-		f.rtcp.PacketChunks = append(f.rtcp.PacketChunks, f.chunks...)
 	}
+	f.rtcp.PacketChunks = append(f.rtcp.PacketChunks, f.chunks...)
 	f.rtcp.RecvDeltas = f.deltas
 
 	padLen := 20 + len(f.rtcp.PacketChunks)*2 + f.len // 4 bytes header + 16 bytes twcc header + 2 bytes for each chunk + length of deltas


### PR DESCRIPTION
#### Description

Always encode all of the remaining deltas in the last chunk. This did
not happen, when the chunk contained more than 7 but less than 14
deltas. This can happen, if we added 8 symbols that fit in one symbol,
but then had to start a new chunk, because the next symbol was too big.

Also happens, if we're done after more than 7, but less than 14 symbols.
In this case, it might be possible to optimize for space and only use
one symbol, but in most cases this will not make a difference and we
would have to check if the chunk only contains symbols that can be
represented by 1 bit.
