### PR TITLE
Fix NACK interceptor sendBuffer overridden

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -9,6 +9,7 @@ aler9 <46489434+aler9@users.noreply.github.com>
 Antoine Baché <antoine@tenten.app>
 Atsushi Watanabe <atsushi.w@ieee.org>
 boks1971 <raja.gobi@tutanota.com>
+David Zhao <david@davidzhao.com>
 Jonathan Müller <jonathan@fotokite.com>
 Mathis Engelbart <mathis.engelbart@gmail.com>
 Sean DuBois <sean@siobud.com>

--- a/pkg/nack/errors.go
+++ b/pkg/nack/errors.go
@@ -4,3 +4,5 @@ import "errors"
 
 // ErrInvalidSize is returned by newReceiveLog/newSendBuffer, when an incorrect buffer size is supplied.
 var ErrInvalidSize = errors.New("invalid buffer size")
+
+var errPacketReleased = errors.New("could not retain packet, already released")

--- a/pkg/nack/retainable_packet.go
+++ b/pkg/nack/retainable_packet.go
@@ -1,0 +1,105 @@
+package nack
+
+import (
+	"io"
+	"sync"
+
+	"github.com/pion/rtp"
+)
+
+const maxPayloadLen = 1460
+
+type packetManager struct {
+	headerPool  *sync.Pool
+	payloadPool *sync.Pool
+}
+
+func newPacketManager() *packetManager {
+	return &packetManager{
+		headerPool: &sync.Pool{
+			New: func() interface{} {
+				return &rtp.Header{}
+			},
+		},
+		payloadPool: &sync.Pool{
+			New: func() interface{} {
+				buf := make([]byte, maxPayloadLen)
+				return &buf
+			},
+		},
+	}
+}
+
+func (m *packetManager) NewPacket(header *rtp.Header, payload []byte) (*retainablePacket, error) {
+	if len(payload) > maxPayloadLen {
+		return nil, io.ErrShortBuffer
+	}
+
+	p := &retainablePacket{
+		onRelease: m.releasePacket,
+		// new packets have retain count of 1
+		count: 1,
+	}
+
+	p.header = m.headerPool.Get().(*rtp.Header)
+	*p.header = header.Clone()
+
+	if payload != nil {
+		p.buffer = m.payloadPool.Get().(*[]byte)
+		size := copy(*p.buffer, payload)
+		p.payload = (*p.buffer)[:size]
+	}
+
+	return p, nil
+}
+
+func (m *packetManager) releasePacket(header *rtp.Header, payload *[]byte) {
+	m.headerPool.Put(header)
+	if payload != nil {
+		m.payloadPool.Put(payload)
+	}
+}
+
+type retainablePacket struct {
+	onRelease func(*rtp.Header, *[]byte)
+
+	countMu sync.Mutex
+	count   int
+
+	header  *rtp.Header
+	buffer  *[]byte
+	payload []byte
+}
+
+func (p *retainablePacket) Header() *rtp.Header {
+	return p.header
+}
+
+func (p *retainablePacket) Payload() []byte {
+	return p.payload
+}
+
+func (p *retainablePacket) Retain() error {
+	p.countMu.Lock()
+	defer p.countMu.Unlock()
+	if p.count == 0 {
+		// already released
+		return errPacketReleased
+	}
+	p.count++
+	return nil
+}
+
+func (p *retainablePacket) Release() {
+	p.countMu.Lock()
+	defer p.countMu.Unlock()
+	p.count--
+
+	if p.count == 0 {
+		// release back to pool
+		p.onRelease(p.header, p.buffer)
+		p.header = nil
+		p.buffer = nil
+		p.payload = nil
+	}
+}

--- a/pkg/nack/send_buffer.go
+++ b/pkg/nack/send_buffer.go
@@ -3,8 +3,6 @@ package nack
 import (
 	"fmt"
 	"sync"
-
-	"github.com/pion/rtp"
 )
 
 const (
@@ -12,7 +10,7 @@ const (
 )
 
 type sendBuffer struct {
-	packets   []*rtp.Packet
+	packets   []*retainablePacket
 	size      uint16
 	lastAdded uint16
 	started   bool
@@ -36,16 +34,16 @@ func newSendBuffer(size uint16) (*sendBuffer, error) {
 	}
 
 	return &sendBuffer{
-		packets: make([]*rtp.Packet, size),
+		packets: make([]*retainablePacket, size),
 		size:    size,
 	}, nil
 }
 
-func (s *sendBuffer) add(packet *rtp.Packet) {
+func (s *sendBuffer) add(packet *retainablePacket) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	seq := packet.SequenceNumber
+	seq := packet.Header().SequenceNumber
 	if !s.started {
 		s.packets[seq%s.size] = packet
 		s.lastAdded = seq
@@ -58,15 +56,25 @@ func (s *sendBuffer) add(packet *rtp.Packet) {
 		return
 	} else if diff < uint16SizeHalf {
 		for i := s.lastAdded + 1; i != seq; i++ {
-			s.packets[i%s.size] = nil
+			idx := i % s.size
+			prevPacket := s.packets[idx]
+			if prevPacket != nil {
+				prevPacket.Release()
+			}
+			s.packets[idx] = nil
 		}
 	}
 
-	s.packets[seq%s.size] = packet
+	idx := seq % s.size
+	prevPacket := s.packets[idx]
+	if prevPacket != nil {
+		prevPacket.Release()
+	}
+	s.packets[idx] = packet
 	s.lastAdded = seq
 }
 
-func (s *sendBuffer) get(seq uint16) *rtp.Packet {
+func (s *sendBuffer) get(seq uint16) *retainablePacket {
 	s.m.RLock()
 	defer s.m.RUnlock()
 
@@ -79,5 +87,15 @@ func (s *sendBuffer) get(seq uint16) *rtp.Packet {
 		return nil
 	}
 
-	return s.packets[seq%s.size]
+	pkt := s.packets[seq%s.size]
+	if pkt != nil {
+		if pkt.Header().SequenceNumber != seq {
+			return nil
+		}
+		// already released
+		if err := pkt.Retain(); err != nil {
+			return nil
+		}
+	}
+	return pkt
 }


### PR DESCRIPTION
Keeps a copy of packet in responder_interceptor, fixes #84

While trying to fix this, I was also thinking about how we might reduce copy/allocations throughout pion. Have implemented a version of this that works within intercepters (unexported for now). any feedback is welcome!