### PR TITLE
Update TWCC error message

### DIFF
--- a/internal/cc/feedback_adapter.go
+++ b/internal/cc/feedback_adapter.go
@@ -15,8 +15,9 @@ import (
 const TwccExtensionAttributesKey = iota
 
 var (
-	errMissingTWCCExtension  = errors.New("missing transport layer cc header extension")
-	errUnknownFeedbackFormat = errors.New("unknown feedback format")
+	errMissingTWCCExtensionID = errors.New("missing transport layer cc header extension id")
+	errMissingTWCCExtension   = errors.New("missing transport layer cc header extension")
+	errUnknownFeedbackFormat  = errors.New("unknown feedback format")
 
 	errInvalidFeedback = errors.New("invalid feedback")
 )
@@ -41,13 +42,13 @@ func (f *FeedbackAdapter) OnSent(ts time.Time, header *rtp.Header, size int, att
 	hdrExtensionID := attributes.Get(TwccExtensionAttributesKey)
 	id, ok := hdrExtensionID.(uint8)
 	if !ok || hdrExtensionID == 0 {
-		return errMissingTWCCExtension
+		return errMissingTWCCExtensionID
 	}
 	sequenceNumber := header.GetExtension(id)
 	var tccExt rtp.TransportCCExtension
 	err := tccExt.Unmarshal(sequenceNumber)
 	if err != nil {
-		return err
+		return errMissingTWCCExtension
 	}
 
 	f.lock.Lock()


### PR DESCRIPTION
#### Description
Previously when the TWCC header extension was present but the
sequence numbers weren't added, the error message reported was
`failed to write packet: buffer too small`. This was difficult
to debug, so now the error message properly reports that the
TWCC header value was not set.

#### Reference issue

