### PR TITLE
Move sender report generation into sender_stream.go

### DIFF
--- a/pkg/report/sender_interceptor.go
+++ b/pkg/report/sender_interceptor.go
@@ -99,21 +99,9 @@ func (s *SenderInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 		case <-ticker.C:
 			now := s.now()
 			s.streams.Range(func(key, value interface{}) bool {
-				ssrc := key.(uint32)
 				stream := value.(*senderStream)
 
-				stream.m.Lock()
-				defer stream.m.Unlock()
-
-				sr := &rtcp.SenderReport{
-					SSRC:        ssrc,
-					NTPTime:     ntpTime(now),
-					RTPTime:     stream.lastRTPTimeRTP + uint32(now.Sub(stream.lastRTPTimeTime).Seconds()*stream.clockRate),
-					PacketCount: stream.packetCount,
-					OctetCount:  stream.octetCount,
-				}
-
-				if _, err := rtcpWriter.Write([]rtcp.Packet{sr}, interceptor.Attributes{}); err != nil {
+				if _, err := rtcpWriter.Write([]rtcp.Packet{stream.generateReport(now)}, interceptor.Attributes{}); err != nil {
 					s.log.Warnf("failed sending: %+v", err)
 				}
 
@@ -129,7 +117,7 @@ func (s *SenderInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 // BindLocalStream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
 // will be called once per rtp packet.
 func (s *SenderInterceptor) BindLocalStream(info *interceptor.StreamInfo, writer interceptor.RTPWriter) interceptor.RTPWriter {
-	stream := newSenderStream(info.ClockRate)
+	stream := newSenderStream(info.SSRC, info.ClockRate)
 	s.streams.Store(info.SSRC, stream)
 
 	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, a interceptor.Attributes) (int, error) {

--- a/pkg/report/sender_stream.go
+++ b/pkg/report/sender_stream.go
@@ -4,10 +4,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 )
 
 type senderStream struct {
+	ssrc      uint32
 	clockRate float64
 	m         sync.Mutex
 
@@ -18,8 +20,9 @@ type senderStream struct {
 	octetCount      uint32
 }
 
-func newSenderStream(clockRate uint32) *senderStream {
+func newSenderStream(ssrc uint32, clockRate uint32) *senderStream {
 	return &senderStream{
+		ssrc:      ssrc,
 		clockRate: float64(clockRate),
 	}
 }
@@ -34,4 +37,17 @@ func (stream *senderStream) processRTP(now time.Time, header *rtp.Header, payloa
 
 	stream.packetCount++
 	stream.octetCount += uint32(len(payload))
+}
+
+func (stream *senderStream) generateReport(now time.Time) *rtcp.SenderReport {
+	stream.m.Lock()
+	defer stream.m.Unlock()
+
+	return &rtcp.SenderReport{
+		SSRC:        stream.ssrc,
+		NTPTime:     ntpTime(now),
+		RTPTime:     stream.lastRTPTimeRTP + uint32(now.Sub(stream.lastRTPTimeTime).Seconds()*stream.clockRate),
+		PacketCount: stream.packetCount,
+		OctetCount:  stream.octetCount,
+	}
 }


### PR DESCRIPTION
#### Description

In this way, receiver and sender report generators are aligned
