### PR TITLE
Make TWCC wait until first packet before reporting

### DIFF
--- a/pkg/twcc/sender_interceptor.go
+++ b/pkg/twcc/sender_interceptor.go
@@ -166,6 +166,13 @@ func (s *SenderInterceptor) isClosed() bool {
 func (s *SenderInterceptor) loop(w interceptor.RTCPWriter) {
 	defer s.wg.Done()
 
+	select {
+	case <-s.close:
+		return
+	case p := <-s.packetChan:
+		s.recorder.Record(p.ssrc, p.sequenceNumber, p.arrivalTime)
+	}
+
 	ticker := time.NewTicker(s.interval)
 	for {
 		select {


### PR DESCRIPTION
TWCC currently starts sending empty reports as soon as an RTCP writer is
setup. This leads to errors before the connection is setup properly.
This change makes the interceptor wait until the first packet arrived
before sending any reports.