### PR TITLE
fix(ss-bwe): `WriteRTCP` raise panic after `Close`

### DIFF
--- a/pkg/gcc/send_side_bwe_test.go
+++ b/pkg/gcc/send_side_bwe_test.go
@@ -98,8 +98,8 @@ func TestSendSideBWE_ErrorOnWriteRTCPAtClosedState(t *testing.T) {
 
 	pkts := []rtcp.Packet{&rtcp.TransportLayerCC{}}
 	require.NoError(t, bwe.WriteRTCP(pkts, nil))
-	require.Equal(t, bwe.IsClosed(), false)
+	require.Equal(t, bwe.isClosed(), false)
 	require.NoError(t, bwe.Close())
 	require.ErrorIs(t, bwe.WriteRTCP(pkts, nil), ErrSendSideBWEClosed)
-	require.Equal(t, bwe.IsClosed(), true)
+	require.Equal(t, bwe.isClosed(), true)
 }

--- a/pkg/gcc/send_side_bwe_test.go
+++ b/pkg/gcc/send_side_bwe_test.go
@@ -90,3 +90,16 @@ func TestSendSideBWE(t *testing.T) {
 	// Sending a stream with zero loss and no RTT should increase estimate
 	require.Less(t, latestBitrate, bwe.GetTargetBitrate())
 }
+
+func TestSendSideBWE_ErrorOnWriteRTCPAtClosedState(t *testing.T) {
+	bwe, err := NewSendSideBWE()
+	require.NoError(t, err)
+	require.NotNil(t, bwe)
+
+	pkts := []rtcp.Packet{&rtcp.TransportLayerCC{}}
+	require.NoError(t, bwe.WriteRTCP(pkts, nil))
+	require.Equal(t, bwe.IsClosed(), false)
+	require.NoError(t, bwe.Close())
+	require.ErrorIs(t, bwe.WriteRTCP(pkts, nil), ErrSendSideBWEClosed)
+	require.Equal(t, bwe.IsClosed(), true)
+}


### PR DESCRIPTION
#### Description
Return an error when `WriteRTCP` is called after the `SendSideBWE` is closed

#### Reference issue
Fixes #131 
