### PR TITLE
Clean up delay based bwe and use less goroutines

### DIFF
--- a/pkg/gcc/arrival_group_accumulator_test.go
+++ b/pkg/gcc/arrival_group_accumulator_test.go
@@ -160,7 +160,13 @@ func TestArrivalGroupAccumulator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			aga := newArrivalGroupAccumulator()
 			in := make(chan cc.Acknowledgment)
-			out := aga.run(in)
+			out := make(chan arrivalGroup)
+			go func() {
+				defer close(out)
+				aga.run(in, func(ag arrivalGroup) {
+					out <- ag
+				})
+			}()
 			go func() {
 				for _, as := range tc.log {
 					in <- as

--- a/pkg/gcc/overuse_detector.go
+++ b/pkg/gcc/overuse_detector.go
@@ -11,69 +11,69 @@ type threshold interface {
 type overuseDetector struct {
 	threshold   threshold
 	overuseTime time.Duration
+
+	dsWriter func(DelayStats)
+
+	lastEstimate       time.Duration
+	lastUpdate         time.Time
+	increasingDuration time.Duration
+	increasingCounter  int
 }
 
-func newOveruseDetector(thresh threshold, overuseTime time.Duration) *overuseDetector {
+func newOveruseDetector(thresh threshold, overuseTime time.Duration, dsw func(DelayStats)) *overuseDetector {
 	return &overuseDetector{
-		threshold:   thresh,
-		overuseTime: overuseTime,
+		threshold:          thresh,
+		overuseTime:        overuseTime,
+		dsWriter:           dsw,
+		lastEstimate:       0,
+		lastUpdate:         time.Now(),
+		increasingDuration: 0,
+		increasingCounter:  0,
 	}
 }
 
-func (d *overuseDetector) run(in <-chan DelayStats) <-chan DelayStats {
-	out := make(chan DelayStats)
-	go func() {
-		lastEstimate := 0 * time.Millisecond
-		lastUpdate := time.Now()
-		var increasingDuration time.Duration
-		var increasingCounter int
+func (d *overuseDetector) onDelayStats(ds DelayStats) {
+	now := time.Now()
+	delta := now.Sub(d.lastUpdate)
+	d.lastUpdate = now
 
-		for next := range in {
-			now := time.Now()
-			delta := now.Sub(lastUpdate)
-			lastUpdate = now
+	thresholdUse, estimate, currentThreshold := d.threshold.compare(ds.Estimate, ds.lastReceiveDelta)
 
-			thresholdUse, estimate, currentThreshold := d.threshold.compare(next.Estimate, next.lastReceiveDelta)
-
-			use := usageNormal
-			if thresholdUse == usageOver {
-				if increasingDuration == 0 {
-					increasingDuration = delta / 2
-				} else {
-					increasingDuration += delta
-				}
-				increasingCounter++
-				if increasingDuration > d.overuseTime && increasingCounter > 1 {
-					if estimate > lastEstimate {
-						use = usageOver
-					}
-				}
-			}
-			if thresholdUse == usageUnder {
-				increasingCounter = 0
-				increasingDuration = 0
-				use = usageUnder
-			}
-
-			if thresholdUse == usageNormal {
-				increasingDuration = 0
-				increasingCounter = 0
-				use = usageNormal
-			}
-			lastEstimate = estimate
-
-			out <- DelayStats{
-				Measurement:      next.Measurement,
-				Estimate:         estimate,
-				Threshold:        currentThreshold,
-				lastReceiveDelta: delta,
-				Usage:            use,
-				State:            0,
-				TargetBitrate:    0,
-				RTT:              0,
+	use := usageNormal
+	if thresholdUse == usageOver {
+		if d.increasingDuration == 0 {
+			d.increasingDuration = delta / 2
+		} else {
+			d.increasingDuration += delta
+		}
+		d.increasingCounter++
+		if d.increasingDuration > d.overuseTime && d.increasingCounter > 1 {
+			if estimate > d.lastEstimate {
+				use = usageOver
 			}
 		}
-		close(out)
-	}()
-	return out
+	}
+	if thresholdUse == usageUnder {
+		d.increasingCounter = 0
+		d.increasingDuration = 0
+		use = usageUnder
+	}
+
+	if thresholdUse == usageNormal {
+		d.increasingDuration = 0
+		d.increasingCounter = 0
+		use = usageNormal
+	}
+	d.lastEstimate = estimate
+
+	d.dsWriter(DelayStats{
+		Measurement:      ds.Measurement,
+		Estimate:         estimate,
+		Threshold:        currentThreshold,
+		lastReceiveDelta: delta,
+		Usage:            use,
+		State:            0,
+		TargetBitrate:    0,
+		RTT:              0,
+	})
 }

--- a/pkg/gcc/rate_calculator.go
+++ b/pkg/gcc/rate_calculator.go
@@ -16,49 +16,44 @@ func newRateCalculator(window time.Duration) *rateCalculator {
 	}
 }
 
-func (c *rateCalculator) run(in <-chan cc.Acknowledgment) <-chan int {
-	out := make(chan int)
-	go func() {
-		var history []cc.Acknowledgment
-		init := false
-		sum := 0
-		for next := range in {
-			if next.Arrival.IsZero() {
-				// Ignore packet if it didn't arrive
-				continue
-			}
-			history = append(history, next)
-			sum += next.Size
-
-			if !init {
-				init = true
-				// Don't know any timeframe here, only arrival of last packet,
-				// which is by definition in the window that ends with the last
-				// arrival time
-				out <- next.Size * 8
-				continue
-			}
-
-			del := 0
-			for _, ack := range history {
-				deadline := next.Arrival.Add(-c.window)
-				if !ack.Arrival.Before(deadline) {
-					break
-				}
-				del++
-				sum -= ack.Size
-			}
-			history = history[del:]
-			if len(history) == 0 {
-				out <- 0
-				continue
-			}
-			dt := next.Arrival.Sub(history[0].Arrival)
-			bits := 8 * sum
-			rate := int(float64(bits) / dt.Seconds())
-			out <- rate
+func (c *rateCalculator) run(in <-chan cc.Acknowledgment, onRateUpdate func(int)) {
+	var history []cc.Acknowledgment
+	init := false
+	sum := 0
+	for next := range in {
+		if next.Arrival.IsZero() {
+			// Ignore packet if it didn't arrive
+			continue
 		}
-		close(out)
-	}()
-	return out
+		history = append(history, next)
+		sum += next.Size
+
+		if !init {
+			init = true
+			// Don't know any timeframe here, only arrival of last packet,
+			// which is by definition in the window that ends with the last
+			// arrival time
+			onRateUpdate(next.Size * 8)
+			continue
+		}
+
+		del := 0
+		for _, ack := range history {
+			deadline := next.Arrival.Add(-c.window)
+			if !ack.Arrival.Before(deadline) {
+				break
+			}
+			del++
+			sum -= ack.Size
+		}
+		history = history[del:]
+		if len(history) == 0 {
+			onRateUpdate(0)
+			continue
+		}
+		dt := next.Arrival.Sub(history[0].Arrival)
+		bits := 8 * sum
+		rate := int(float64(bits) / dt.Seconds())
+		onRateUpdate(rate)
+	}
 }

--- a/pkg/gcc/rate_calculator_test.go
+++ b/pkg/gcc/rate_calculator_test.go
@@ -80,11 +80,16 @@ func TestRateCalculator(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			rc := rateCalculator{
-				window: 500 * time.Millisecond,
-			}
+			rc := newRateCalculator(500 * time.Millisecond)
 			in := make(chan cc.Acknowledgment)
-			out := rc.run(in)
+			out := make(chan int)
+			onRateUpdate := func(rate int) {
+				out <- rate
+			}
+			go func() {
+				defer close(out)
+				rc.run(in, onRateUpdate)
+			}()
 			go func() {
 				for _, ack := range tc.acks {
 					in <- ack

--- a/pkg/gcc/rtt_estimator.go
+++ b/pkg/gcc/rtt_estimator.go
@@ -17,33 +17,28 @@ func newRTTEstimator() *rttEstimator {
 	}
 }
 
-func (e *rttEstimator) run(in <-chan []cc.Acknowledgment) <-chan time.Duration {
-	out := make(chan time.Duration)
-	go func() {
-		history := []time.Duration{}
-		for acks := range in {
-			if len(acks) == 0 {
-				continue
-			}
-			minRTT := time.Duration(math.MaxInt64)
-			for _, ack := range acks {
-				if ack.RTT < minRTT {
-					minRTT = ack.RTT
-				}
-			}
-			history = append(history, minRTT)
-			if len(history) >= e.samples {
-				history = history[len(history)-e.samples:]
-			}
-
-			sum := time.Duration(0)
-			for _, rtt := range history {
-				sum += rtt
-			}
-			rtt := float64(sum.Milliseconds()) / float64(len(history)) * float64(time.Millisecond)
-			out <- time.Duration(rtt)
+func (e *rttEstimator) run(in <-chan []cc.Acknowledgment, onRTTUpdate func(time.Duration)) {
+	history := []time.Duration{}
+	for acks := range in {
+		if len(acks) == 0 {
+			continue
 		}
-		close(out)
-	}()
-	return out
+		minRTT := time.Duration(math.MaxInt64)
+		for _, ack := range acks {
+			if ack.RTT < minRTT {
+				minRTT = ack.RTT
+			}
+		}
+		history = append(history, minRTT)
+		if len(history) >= e.samples {
+			history = history[len(history)-e.samples:]
+		}
+
+		sum := time.Duration(0)
+		for _, rtt := range history {
+			sum += rtt
+		}
+		rtt := float64(sum.Milliseconds()) / float64(len(history)) * float64(time.Millisecond)
+		onRTTUpdate(time.Duration(rtt))
+	}
 }

--- a/pkg/gcc/rtt_estimator_test.go
+++ b/pkg/gcc/rtt_estimator_test.go
@@ -57,7 +57,13 @@ func TestRTTEstimator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			re := newRTTEstimator()
 			in := make(chan []cc.Acknowledgment)
-			out := re.run(in)
+			out := make(chan time.Duration)
+			go func() {
+				defer close(out)
+				re.run(in, func(d time.Duration) {
+					out <- d
+				})
+			}()
 			go func() {
 				for _, acks := range tc.ackLists {
 					in <- acks

--- a/pkg/gcc/slope_estimator_test.go
+++ b/pkg/gcc/slope_estimator_test.go
@@ -91,15 +91,16 @@ func TestSlopeEstimator(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			se := newSlopeEstimator(estimatorFunc(identity))
-			in := make(chan arrivalGroup)
-			out := se.run(in)
+			out := make(chan DelayStats)
+			se := newSlopeEstimator(estimatorFunc(identity), func(ds DelayStats) {
+				out <- ds
+			})
 			input := []time.Duration{}
 			go func() {
+				defer close(out)
 				for _, ag := range tc.ags {
-					in <- ag
+					se.onArrivalGroup(ag)
 				}
-				close(in)
 			}()
 			received := []DelayStats{}
 			for d := range out {


### PR DESCRIPTION
Reduces the number of goroutines that are spawned for a process that always runs sequentially anyway. Additionally, cleans up and moves some code to more appropriate files.