### PR TITLE
Fix stats recorder actions that block when not yet started or stopped

### DIFF
--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -92,7 +92,7 @@ func (a *adaptiveThreshold) update(estimate time.Duration) {
 	timeDelta := time.Duration(minInt(int(now.Sub(a.lastUpdate).Milliseconds()), int(maxTimeDelta.Milliseconds()))) * time.Millisecond
 	d := absEstimate - a.thresh
 	add := k * float64(d.Milliseconds()) * float64(timeDelta.Milliseconds())
-	a.thresh += time.Duration(add * 1000) * time.Microsecond
+	a.thresh += time.Duration(add*1000) * time.Microsecond
 	a.thresh = clampDuration(a.thresh, a.min, a.max)
 	a.lastUpdate = now
 }


### PR DESCRIPTION
When closing a `PeerConnection` that is using the stats recorder as an interceptor, the process may block. I've dug a little bit and found out the calls to `GetStats()`, `QueueIncomingRTP()`, `QueueIncomingRTCP()`, `QueueOutgoingRTP()` and `QueueOutgoingRTCP()` block when the recorder is not yet started or stopped. I've added both `TestGetStatsNotBlocking` and `TestQueueNotBlocking` tests to test this.

I've proposed a fix which consists of replacing channels with mutexes but an alternative would be to wrap channel calls around a mutex.

Let me know what you think.
Cheers 