### PR TITLE
GetStats does not block after Close() is called

### DIFF
--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -106,6 +106,8 @@ func (r *recorder) Stop() {
 	close(r.done)
 }
 
+// GetStats returns the Stats object. If Stop() has been called, GetStats() will return
+// a zero value Stats struct.
 func (r *recorder) GetStats() Stats {
 	return <-r.getStatsChan
 }
@@ -265,6 +267,7 @@ func (r *recorder) Start() {
 	for {
 		select {
 		case <-r.done:
+			close(r.getStatsChan)
 			return
 		case v := <-r.incomingRTPChan:
 			s := r.recordIncomingRTP(*latestStats, v)

--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -119,12 +119,10 @@ func (r *recorder) Stop() {
 }
 
 func (r *recorder) GetStats() Stats {
-	select {
-	case <-r.done:
-		return r.latestStats.Stats()
-	default:
+	if stats, ok := <-r.getStatsChan; ok {
+		return stats
 	}
-	return <-r.getStatsChan
+	return r.latestStats.Stats()
 }
 
 func (r *recorder) recordIncomingRTP(latestStats internalStats, v *incomingRTP) internalStats {


### PR DESCRIPTION
#### Description

GetStats() will block after `Close()` is called. This occurs because GetStats() pulls from a channel that doesn't get closed after `Close` is called.

This PR closes the channel and does a `ok` check when pulling from the `getStatsChan`.


