### PR TITLE
BugFix: When calculating dlrr, precision is lost in integer operations, errors occur in rtt calculations.

### DIFF
--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -223,7 +223,7 @@ func (r *recorder) recordIncomingXR(latestStats internalStats, pkt *rtcp.Extende
 					for i := min(r.maxLastReceiverReferenceTimes, len(latestStats.lastReceiverReferenceTimes)) - 1; i >= 0; i-- {
 						lastRR := latestStats.lastReceiverReferenceTimes[i]
 						if (lastRR&0x0000FFFFFFFF0000)>>16 == uint64(xrReport.LastRR) {
-							dlrr := time.Duration(xrReport.DLRR/65536.0) * time.Second
+							dlrr := time.Duration(float64(xrReport.DLRR) / 65536.0 * float64(time.Second))
 							latestStats.RemoteOutboundRTPStreamStats.RoundTripTime = (ts.Add(-dlrr)).Sub(ntp.ToTime(lastRR))
 							latestStats.RemoteOutboundRTPStreamStats.TotalRoundTripTime += latestStats.RemoteOutboundRTPStreamStats.RoundTripTime
 							latestStats.RemoteOutboundRTPStreamStats.RoundTripTimeMeasurements++

--- a/pkg/stats/stats_recorder_test.go
+++ b/pkg/stats/stats_recorder_test.go
@@ -289,3 +289,27 @@ func TestStatsRecorder(t *testing.T) {
 		})
 	}
 }
+
+func TestStatsRecorder_DLRR_Precision(t *testing.T) {
+	r := newRecorder(0, 90_000)
+
+	report := &rtcp.ExtendedReport{
+		Reports: []rtcp.ReportBlock{
+			&rtcp.DLRRReportBlock{
+				Reports: []rtcp.DLRRReport{
+					{
+						SSRC:   5000,
+						LastRR: 762,
+						DLRR:   30000,
+					},
+				},
+			},
+		},
+	}
+
+	s := r.recordIncomingXR(internalStats{
+		lastReceiverReferenceTimes: []uint64{50000000},
+	}, report, time.Time{})
+
+	assert.Equal(t, int64(s.RemoteOutboundRTPStreamStats.RoundTripTime), int64(-9223372036854775808))
+}


### PR DESCRIPTION
#### Description
 `time.Duration(xrReport.DLRR/65536.0)`  
 This will cause precision lost. for example, when xrReport.DLRR=30000, result 0 is unexpected. 
 Following the method just like dlsr
`dlsr := time.Duration(float64(report.Delay) / 65536.0 * float64(time.Second))`
