### PR TITLE
Fix a bug in adaptive_threshold

### DIFF
--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -92,7 +92,7 @@ func (a *adaptiveThreshold) update(estimate time.Duration) {
 	timeDelta := time.Duration(minInt(int(now.Sub(a.lastUpdate).Milliseconds()), int(maxTimeDelta.Milliseconds()))) * time.Millisecond
 	d := absEstimate - a.thresh
 	add := k * float64(d.Milliseconds()) * float64(timeDelta.Milliseconds())
-	a.thresh += time.Duration(add) * 1000 * time.Microsecond
+	a.thresh += time.Duration(add * 1000) * time.Microsecond
 	a.thresh = clampDuration(a.thresh, a.min, a.max)
 	a.lastUpdate = now
 }


### PR DESCRIPTION
#### Description
Fig bug: in adaptive_threshold.go, the add,time.Duration() will round add, and adjustment of the threshold will always be zeros.
#### Reference issue
we print information as follows
`fmt.Printf("thresh: %f,%s,%s\n",add,time.Duration(add)*1000* time.Microsecond,time.Duration(add*1000)* time.Microsecond)`

![2023-03-26 17-06-33屏幕截图](https://user-images.githubusercontent.com/35365588/227765956-8ce56f64-b8fa-441d-95bd-5e44883e845a.png)
