### PR TITLE
Don't discarding if TWCC Generator isn't ready

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,7 +8,6 @@ Adam Kiss <masterada@gmail.com>
 adamroach <adam@nostrum.com>
 Aditya Kumar <k.aditya00@gmail.com>
 aler9 <46489434+aler9@users.noreply.github.com>
-Antoine <antoine@tenten.app>
 Antoine Baché <antoine@tenten.app>
 Atsushi Watanabe <atsushi.w@ieee.org>
 Bobby Peck <rpeck@mux.com>
@@ -18,8 +17,12 @@ Jonathan Müller <jonathan@fotokite.com>
 Kevin Caffrey <kcaffrey@gmail.com>
 Maksim Nesterov <msnesterov@avito.ru>
 Mathis Engelbart <mathis.engelbart@gmail.com>
+Quentin Renard <contact@asticode.com>
+Rayleigh Li <rayleigh.li@zoom.us>
+Sean <sean@siobud.com>
 Sean DuBois <sean@siobud.com>
 Steffen Vogel <post@steffenvogel.de>
+XLPolar <guangjin_pan@163.com>
 ziminghua <565209960@qq.com>
 
 # List of contributors not appearing in Git history

--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -70,13 +70,12 @@ func insertSorted(list []pktInfo, element pktInfo) []pktInfo {
 
 // BuildFeedbackPacket creates a new RTCP packet containing a TWCC feedback report.
 func (r *Recorder) BuildFeedbackPacket() []rtcp.Packet {
-	feedback := newFeedback(r.senderSSRC, r.mediaSSRC, r.fbPktCnt)
-	r.fbPktCnt++
 	if len(r.receivedPackets) < 2 {
-		r.receivedPackets = []pktInfo{}
-		return []rtcp.Packet{feedback.getRTCP()}
+		return nil
 	}
 
+	feedback := newFeedback(r.senderSSRC, r.mediaSSRC, r.fbPktCnt)
+	r.fbPktCnt++
 	feedback.setBase(uint16(r.receivedPackets[0].sequenceNumber&0xffff), r.receivedPackets[0].arrivalTime)
 
 	var pkts []rtcp.Packet


### PR DESCRIPTION
Instead return nil to the caller and don't modify any internal state

Resolves #159
