### PR TITLE
Filter packets and reports by SSRC

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -16,10 +16,10 @@ David Zhao <david@davidzhao.com>
 Jonathan Müller <jonathan@fotokite.com>
 Kevin Caffrey <kcaffrey@gmail.com>
 Maksim Nesterov <msnesterov@avito.ru>
+Mathis <mathis.engelbart@gmail.com>
 Mathis Engelbart <mathis.engelbart@gmail.com>
 Quentin Renard <contact@asticode.com>
 Rayleigh Li <rayleigh.li@zoom.us>
-Sean <sean@siobud.com>
 Sean DuBois <sean@siobud.com>
 Steffen Vogel <post@steffenvogel.de>
 XLPolar <guangjin_pan@163.com>


### PR DESCRIPTION
Otherwise, we would record packets and reports which do not belong to the stream that is monitored by this recorder.

#### Reference issue
Fixes #166 #168
