### PR TITLE
Fix set extension on nil header

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,6 +17,7 @@ Jonathan Müller <jonathan@fotokite.com>
 Kevin Caffrey <kcaffrey@gmail.com>
 Maksim Nesterov <msnesterov@avito.ru>
 Mathis Engelbart <mathis.engelbart@gmail.com>
+Miroslav <sedivy.miro@gmail.com>
 Miroslav Šedivý <sedivy.miro@gmail.com>
 Quentin Renard <contact@asticode.com>
 Rayleigh Li <rayleigh.li@zoom.us>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -17,6 +17,7 @@ Jonathan Müller <jonathan@fotokite.com>
 Kevin Caffrey <kcaffrey@gmail.com>
 Maksim Nesterov <msnesterov@avito.ru>
 Mathis Engelbart <mathis.engelbart@gmail.com>
+Miroslav Šedivý <sedivy.miro@gmail.com>
 Quentin Renard <contact@asticode.com>
 Rayleigh Li <rayleigh.li@zoom.us>
 Sean DuBois <sean@siobud.com>

--- a/pkg/twcc/header_extension_interceptor.go
+++ b/pkg/twcc/header_extension_interceptor.go
@@ -4,11 +4,14 @@
 package twcc
 
 import (
+	"errors"
 	"sync/atomic"
 
 	"github.com/pion/interceptor"
 	"github.com/pion/rtp"
 )
+
+var errHeaderIsNil = errors.New("header is nil")
 
 // HeaderExtensionInterceptorFactory is a interceptor.Factory for a HeaderExtensionInterceptor
 type HeaderExtensionInterceptorFactory struct{}
@@ -50,6 +53,9 @@ func (h *HeaderExtensionInterceptor) BindLocalStream(info *interceptor.StreamInf
 		tcc, err := (&rtp.TransportCCExtension{TransportSequence: uint16(sequenceNumber)}).Marshal()
 		if err != nil {
 			return 0, err
+		}
+		if header == nil {
+			return 0, errHeaderIsNil
 		}
 		err = header.SetExtension(hdrExtID, tcc)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/pion/interceptor/issues/185

I was not sure about if it should fail silently, ignoring setting header and continue or returning error. I opted for the second, so that it is transparent that something is not right when header is nil.