### PR TITLE
Enable injecting ticker to Sender Report interceptor

### DIFF
--- a/pkg/report/sender_interceptor.go
+++ b/pkg/report/sender_interceptor.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pion/rtp"
 )
 
+// TickerFactory is a factory to create new tickers
+type TickerFactory func(d time.Duration) Ticker
+
 // SenderInterceptorFactory is a interceptor.Factory for a SenderInterceptor
 type SenderInterceptorFactory struct {
 	opts []SenderOption
@@ -23,8 +26,11 @@ func (s *SenderInterceptorFactory) NewInterceptor(_ string) (interceptor.Interce
 	i := &SenderInterceptor{
 		interval: 1 * time.Second,
 		now:      time.Now,
-		log:      logging.NewDefaultLoggerFactory().NewLogger("sender_interceptor"),
-		close:    make(chan struct{}),
+		newTicker: func(d time.Duration) Ticker {
+			return &timeTicker{time.NewTicker(d)}
+		},
+		log:   logging.NewDefaultLoggerFactory().NewLogger("sender_interceptor"),
+		close: make(chan struct{}),
 	}
 
 	for _, opt := range s.opts {
@@ -44,13 +50,15 @@ func NewSenderInterceptor(opts ...SenderOption) (*SenderInterceptorFactory, erro
 // SenderInterceptor interceptor generates sender reports.
 type SenderInterceptor struct {
 	interceptor.NoOp
-	interval time.Duration
-	now      func() time.Time
-	streams  sync.Map
-	log      logging.LeveledLogger
-	m        sync.Mutex
-	wg       sync.WaitGroup
-	close    chan struct{}
+	interval  time.Duration
+	now       func() time.Time
+	newTicker TickerFactory
+	streams   sync.Map
+	log       logging.LeveledLogger
+	m         sync.Mutex
+	wg        sync.WaitGroup
+	close     chan struct{}
+	started   chan struct{}
 }
 
 func (s *SenderInterceptor) isClosed() bool {
@@ -95,11 +103,16 @@ func (s *SenderInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interc
 func (s *SenderInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 	defer s.wg.Done()
 
-	ticker := time.NewTicker(s.interval)
+	ticker := s.newTicker(s.interval)
 	defer ticker.Stop()
+	if s.started != nil {
+		// This lets us synchronize in tests to know whether the loop has begun or not.
+		// It only happens if started was initialized, which should not occur in non-tests.
+		close(s.started)
+	}
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker.Ch():
 			now := s.now()
 			s.streams.Range(func(key, value interface{}) bool {
 				if stream, ok := value.(*senderStream); !ok {

--- a/pkg/report/sender_option.go
+++ b/pkg/report/sender_option.go
@@ -35,3 +35,20 @@ func SenderNow(f func() time.Time) SenderOption {
 		return nil
 	}
 }
+
+// SenderTicker sets an alternative for the time.NewTicker function.
+func SenderTicker(f TickerFactory) SenderOption {
+	return func(r *SenderInterceptor) error {
+		r.newTicker = f
+		return nil
+	}
+}
+
+// enableStartTracking is used by tests to synchronize whether the loop() has begun
+// and it's safe to start sending ticks to the ticker.
+func enableStartTracking(startedCh chan struct{}) SenderOption {
+	return func(r *SenderInterceptor) error {
+		r.started = startedCh
+		return nil
+	}
+}

--- a/pkg/report/ticker.go
+++ b/pkg/report/ticker.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package report
+
+import "time"
+
+// Ticker is an interface for *time.Ticker for use with the SenderTicker option.
+type Ticker interface {
+	Ch() <-chan time.Time
+	Stop()
+}
+
+type timeTicker struct {
+	*time.Ticker
+}
+
+func (t *timeTicker) Ch() <-chan time.Time {
+	return t.C
+}


### PR DESCRIPTION
#### Description

This lets consumers use the Sender Report interceptor in tests that utilize fake clocks. Previously the current time could be injected, but the interceptor would only run according to real-time based on `time.NewTicker`, but now tests can control when the reports are generated.