### PR TITLE
Add PacketsHeld to TWCC recorder

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,6 +3,8 @@
 #
 # This file is auto generated, using git to list all individuals contributors.
 # see https://github.com/pion/.goassets/blob/master/scripts/generate-authors.sh for the scripting
+ Sean DuBois <sean@siobud.com>
+ ziminghua <565209960@qq.com>
 Aaron Boushley <boushley@gmail.com>
 Adam Kiss <masterada@gmail.com>
 adamroach <adam@nostrum.com>
@@ -23,8 +25,8 @@ Quentin Renard <contact@asticode.com>
 Rayleigh Li <rayleigh.li@zoom.us>
 Sean DuBois <sean@siobud.com>
 Steffen Vogel <post@steffenvogel.de>
+treyhakanson <treyhakanson@gmail.com>
 XLPolar <guangjin_pan@163.com>
-ziminghua <565209960@qq.com>
 
 # List of contributors not appearing in Git history
 

--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -51,6 +51,11 @@ func (r *Recorder) Record(mediaSSRC uint32, sequenceNumber uint16, arrivalTime i
 	r.lastSequenceNumber = sequenceNumber
 }
 
+// PacketsHeld returns the number of received packets currently held by the recorder
+func (r *Recorder) PacketsHeld() int {
+	return len(r.receivedPackets)
+}
+
 func insertSorted(list []pktInfo, element pktInfo) []pktInfo {
 	if len(list) == 0 {
 		return append(list, element)

--- a/pkg/twcc/twcc_test.go
+++ b/pkg/twcc/twcc_test.go
@@ -940,3 +940,25 @@ func TestInsertSorted(t *testing.T) {
 		})
 	}
 }
+
+func TestPacketsHheld(t *testing.T) {
+	r := NewRecorder(5000)
+	assert.Zero(t, r.PacketsHeld())
+
+	arrivalTime := int64(scaleFactorReferenceTime)
+	addRun(t, r, []uint16{0, 1, 2}, []int64{
+		arrivalTime,
+		increaseTime(&arrivalTime, rtcp.TypeTCCDeltaScaleFactor),
+		increaseTime(&arrivalTime, rtcp.TypeTCCDeltaScaleFactor),
+	})
+	assert.Equal(t, r.PacketsHeld(), 3)
+
+	addRun(t, r, []uint16{3, 4}, []int64{
+		increaseTime(&arrivalTime, rtcp.TypeTCCDeltaScaleFactor),
+		increaseTime(&arrivalTime, rtcp.TypeTCCDeltaScaleFactor),
+	})
+	assert.Equal(t, r.PacketsHeld(), 5)
+
+	r.BuildFeedbackPacket()
+	assert.Zero(t, r.PacketsHeld())
+}


### PR DESCRIPTION
#### Description

When using `twcc.Recorder` outside the context of `twcc.SenderInterceptor`, it is useful to have access to the number of packets currently held. This enables writing logic other than an interval to determine when to build feedback packets.

#### Reference issue
N/A
