### PR TITLE
Fix wrap around on out of order packet

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,17 +3,17 @@
 #
 # This file is auto generated, using git to list all individuals contributors.
 # see https://github.com/pion/.goassets/blob/master/scripts/generate-authors.sh for the scripting
- Sean DuBois <sean@siobud.com>
- ziminghua <565209960@qq.com>
 Aaron Boushley <boushley@gmail.com>
 Adam Kiss <masterada@gmail.com>
 adamroach <adam@nostrum.com>
 Aditya Kumar <k.aditya00@gmail.com>
+Adrian Cable <6544927+adriancable@users.noreply.github.com>
 aler9 <46489434+aler9@users.noreply.github.com>
 Antoine Baché <antoine@tenten.app>
 Atsushi Watanabe <atsushi.w@ieee.org>
 Bobby Peck <rpeck@mux.com>
 boks1971 <raja.gobi@tutanota.com>
+cptpcrd <31829097+cptpcrd@users.noreply.github.com>
 David Zhao <david@davidzhao.com>
 Jonathan Müller <jonathan@fotokite.com>
 Kevin Caffrey <kcaffrey@gmail.com>
@@ -27,6 +27,7 @@ Sean DuBois <sean@siobud.com>
 Steffen Vogel <post@steffenvogel.de>
 treyhakanson <treyhakanson@gmail.com>
 XLPolar <guangjin_pan@163.com>
+ziminghua <565209960@qq.com>
 
 # List of contributors not appearing in Git history
 

--- a/pkg/report/receiver_interceptor_test.go
+++ b/pkg/report/receiver_interceptor_test.go
@@ -178,6 +178,10 @@ func TestReceiverInterceptor(t *testing.T) {
 			SequenceNumber: 0x00,
 		}})
 
+		stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{
+			SequenceNumber: 0xfffe,
+		}})
+
 		pkts := <-stream.WrittenRTCP()
 		assert.Equal(t, len(pkts), 1)
 		rr, ok := pkts[0].(*rtcp.ReceiverReport)

--- a/pkg/report/receiver_stream.go
+++ b/pkg/report/receiver_stream.go
@@ -64,10 +64,10 @@ func (stream *receiverStream) processRTP(now time.Time, pktHeader *rtp.Header) {
 	} else { // following frames
 		stream.setReceived(pktHeader.SequenceNumber)
 
-		diff := int32(pktHeader.SequenceNumber) - int32(stream.lastSeqnum)
-		if diff > 0 || diff < -0x0FFF {
-			// overflow
-			if diff < -0x0FFF {
+		diff := pktHeader.SequenceNumber - stream.lastSeqnum
+		if diff > 0 && diff < (1<<15) {
+			// wrap around
+			if pktHeader.SequenceNumber < stream.lastSeqnum {
 				stream.seqnumCycles++
 			}
 


### PR DESCRIPTION
Sequence number cycle calculation was over estimating the cycles if packets came out of order. A sequence like 65535, 0, 65534 would increment the cycle counter twice.