### PR TITLE
Do not send empty NACK packets

### DIFF
--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -191,6 +191,10 @@ func (n *GeneratorInterceptor) loop(rtcpWriter interceptor.RTCPWriter) {
 						}
 					}
 
+					if len(filteredMissing) == 0 {
+						continue
+					}
+
 					if _, err := rtcpWriter.Write([]rtcp.Packet{nack}, interceptor.Attributes{}); err != nil {
 						n.log.Warnf("failed sending nack: %+v", err)
 					}


### PR DESCRIPTION
Following PR #208, the NACK generator interceptor may send NACK RTCP packets even if there are no missing packets to NACK (specifically if the receive log indicates missing packets, but we've already hit the NACK send limit for those so do not need to NACK those any further). This is functionally 'harmless' but wastes link bandwidth. This PR skips sending a NACK RTCP packet if there are no packets to NACK.