### PR TITLE
[FlexFec] Adding support for FlexFec RFC-03

### DIFF
--- a/pkg/flexfec/encoder_interceptor.go
+++ b/pkg/flexfec/encoder_interceptor.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flexfec
+
+import (
+	"github.com/pion/interceptor"
+	"github.com/pion/rtp"
+)
+
+// FecInterceptor implements FlexFec.
+type FecInterceptor struct {
+	interceptor.NoOp
+	flexFecEncoder     FlexEncoder
+	packetBuffer       []rtp.Packet
+	minNumMediaPackets uint32
+}
+
+// FecOption can be used to set initial options on Fec encoder interceptors.
+type FecOption func(d *FecInterceptor) error
+
+// FecInterceptorFactory creates new FecInterceptors.
+type FecInterceptorFactory struct {
+	opts []FecOption
+}
+
+// NewFecInterceptor returns a new Fec interceptor factory.
+func NewFecInterceptor(opts ...FecOption) (*FecInterceptorFactory, error) {
+	return &FecInterceptorFactory{opts: opts}, nil
+}
+
+// NewInterceptor constructs a new FecInterceptor.
+func (r *FecInterceptorFactory) NewInterceptor(_ string) (interceptor.Interceptor, error) {
+	// Hardcoded for now:
+	// Min num media packets to encode FEC -> 5
+	// Min num fec packets -> 1
+
+	interceptor := &FecInterceptor{
+		packetBuffer:       make([]rtp.Packet, 0),
+		minNumMediaPackets: 5,
+	}
+	return interceptor, nil
+}
+
+// BindLocalStream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
+// will be called once per rtp packet.
+func (r *FecInterceptor) BindLocalStream(info *interceptor.StreamInfo, writer interceptor.RTPWriter) interceptor.RTPWriter {
+	// Chromium supports version flexfec-03 of existing draft, this is the one we will configure by default
+	// although we should support configuring the latest (flexfec-20) as well.
+	r.flexFecEncoder = NewFlexEncoder03(info.PayloadType, info.SSRC)
+
+	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
+		r.packetBuffer = append(r.packetBuffer, rtp.Packet{
+			Header:  *header,
+			Payload: payload,
+		})
+
+		// Send the media RTP packet
+		result, err := writer.Write(header, payload, attributes)
+
+		// Send the FEC packets
+		var fecPackets []rtp.Packet
+		if len(r.packetBuffer) == int(r.minNumMediaPackets) {
+			fecPackets = r.flexFecEncoder.EncodeFec(r.packetBuffer, 2)
+
+			for _, fecPacket := range fecPackets {
+				fecResult, fecErr := writer.Write(&fecPacket.Header, fecPacket.Payload, attributes)
+
+				if fecErr != nil && fecResult == 0 {
+					break
+				}
+			}
+			// Reset the packet buffer now that we've sent the corresponding FEC packets.
+			r.packetBuffer = nil
+		}
+
+		return result, err
+	})
+}

--- a/pkg/flexfec/util/bitarray.go
+++ b/pkg/flexfec/util/bitarray.go
@@ -6,73 +6,40 @@ package util
 
 // BitArray provides support for bitmask manipulations.
 type BitArray struct {
-	bytes []byte
-}
-
-// NewBitArray returns a new BitArray. It takes sizeBits as parameter which represents
-// the size of the underlying bitmask.
-func NewBitArray(sizeBits uint32) BitArray {
-	var sizeBytes uint32
-	if sizeBits%8 == 0 {
-		sizeBytes = sizeBits / 8
-	} else {
-		sizeBytes = sizeBits/8 + 1
-	}
-
-	return BitArray{
-		bytes: make([]byte, sizeBytes),
-	}
+	Lo uint64 // leftmost 64 bits
+	Hi uint64 // rightmost 64 bits
 }
 
 // SetBit sets a bit to the specified bit value on the bitmask.
-func (b *BitArray) SetBit(bitIndex uint32, bitValue uint32) {
-	byteIndex := bitIndex / 8
-	bitOffset := uint(bitIndex % 8)
-
-	// Set the specific bit to 1 using bitwise OR
-	if bitValue == 1 {
-		b.bytes[byteIndex] |= 1 << bitOffset
+func (b *BitArray) SetBit(bitIndex uint32) {
+	if bitIndex < 64 {
+		b.Lo |= uint64(0b1) << (63 - bitIndex)
 	} else {
-		b.bytes[byteIndex] |= 0 << bitOffset
+		hiBitIndex := bitIndex - 64
+		b.Hi |= uint64(0b1) << (63 - hiBitIndex)
 	}
+}
+
+// Reset clears the bitmask.
+func (b *BitArray) Reset() {
+	b.Lo = 0
+	b.Hi = 0
 }
 
 // GetBit returns the bit value at a specified index of the bitmask.
 func (b *BitArray) GetBit(bitIndex uint32) uint8 {
-	return b.bytes[bitIndex/8]
-}
-
-// Marshal returns the underlying bitmask.
-func (b *BitArray) Marshal() []byte {
-	return b.bytes
-}
-
-// GetBitValue returns a subsection of the bitmask.
-func (b *BitArray) GetBitValue(i int, j int) uint64 {
-	if i < 0 || i >= len(b.bytes)*8 || j < 0 || j >= len(b.bytes)*8 || i > j {
+	if bitIndex < 64 {
+		result := (b.Lo & (uint64(0b1) << (63 - bitIndex)))
+		if result > 0 {
+			return 1
+		}
 		return 0
 	}
 
-	startByte := i / 8
-	startBit := i % 8
-	endByte := j / 8
-
-	// Create a slice containing the bytes to extract
-	subArray := b.bytes[startByte : endByte+1]
-
-	// Initialize the result value
-	var result uint64
-
-	// Loop through the bytes and concatenate the bits
-	for idx, b := range subArray {
-		if idx == 0 {
-			b <<= uint(startBit)
-		}
-		result |= uint64(b)
+	hiBitIndex := bitIndex - 64
+	result := (b.Hi & (uint64(0b1) << (63 - hiBitIndex)))
+	if result > 0 {
+		return 1
 	}
-
-	// Mask the bits that are not part of the desired range
-	result &= (1<<uint(j-i+1) - 1)
-
-	return result
+	return 0
 }


### PR DESCRIPTION
#### Description

##### Context

This PR is part of a series of PRs to provide FlexFec support for pion.
https://datatracker.ietf.org/doc/html/rfc8627

##### Summary

This PR provides the following:

- Adding a FlexFec encoder implementation for https://datatracker.ietf.org/doc/html/draft-ietf-payload-flexible-fec-scheme-03 => This is the implementation that chromium currently uses instead of the latest version of the draft. Providing support for this draft version will enable pion to work with chromium-based browsers.
- Changing the FEC coverage data structure to use 2 uint64 to store the packet masks. This will reduce allocations.
- Adding support for the actual Interceptor component that batches RTP packets together to generate repair packets before sending both types of packets over the network.
- Various fixes to FEC header encoding, validated with chromium.

There are still some issues to be tackled:
- Hardcoded timestamp for the RTP header. Chromium seems to work just fine with this but we need to properly set this value.
- We currently limit ourselves to VP8, FlexFec is meant to be codec agnostic so we can provide support for more codecs.
- We currently hardcode a minimum of 5 media packets protected by 2 media packets, this should be configurable.
- We need to account for missing media packets, indeed media packets could be dropped on the way to being received by pion, and our FEC encoder assumes there are no missing media packets.


#### Reference issue
Fixes #...
