### PR TITLE
Increase should never decrease

### DIFF
--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -104,7 +104,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 	case stateHold:
 		// should never occur due to check above, but makes the linter happy
 	case stateIncrease:
-		c.target = clampInt(c.increase(now), c.minBitrate, c.maxBitrate)
+		c.target = clampInt(c.increase(now), c.target, c.maxBitrate)
 		next = DelayStats{
 			Measurement:      c.delayStats.Measurement,
 			Estimate:         c.delayStats.Estimate,


### PR DESCRIPTION
When the controller decides to increase the rate, it should not decrease, even if the measured transmission rate was low. The rate could be lower because there was not enough data to send.