### PR TITLE
Fix variance calculation for exponentialMovingAverage

### DIFF
--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -45,7 +45,7 @@ func (a *exponentialMovingAverage) update(value float64) {
 	} else {
 		x := value - a.average
 		a.average += decreaseEMAAlpha * x
-		a.variance = (1 - decreaseEMAAlpha) * (a.variance + decreaseEMAAlpha*x*x)
+		a.variance = decreaseEMAAlpha*x*x + (1-decreaseEMAAlpha)*a.variance
 		a.stdDeviation = math.Sqrt(a.variance)
 	}
 }


### PR DESCRIPTION
Variance calculation for exponentialMovingAverage was incorrect

#### Description
Current equation is 
a.variance = (1 - decreaseEMAAlpha) * (a.variance + decreaseEMAAlpha*x*x) =>
a.variance = a.variance - decreaseEMAAlpha*a.variance + decreaseEMAAlpha*x*x -  decreaseEMAAlpha* decreaseEMAAlpha*x*x
this is not correct. Proposed version is correct one

@mengelbart could you please review my version ? 

#### Reference issue
