### PR TITLE
Don't double update uncertainty

### DIFF
--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -80,8 +80,9 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 		root3 := 3 * root
 		if zms > root3 {
 			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*root3*root3, 1)
+		} else {
+			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 		}
-		k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 	}
 
 	estimateUncertainty := k.estimateError + k.processUncertainty


### PR DESCRIPTION
Standard says we need to use either 3*sqrt(var_v_hat) or z(i)

#### Description
Here is quote from

`
If z(i) > 3*sqrt(var_v_hat) the filter is updated with 3*sqrt(var_v_hat) rather than z(i)
`

rather means we need to update uncertainty with 3*sqrt(var_v_hat) and don't add z(i) this time

#### Reference issue
Fixes #...
