### PR TITLE
Bandwidth estimator improvements

### DIFF
--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -8,10 +8,6 @@ import (
 	"time"
 )
 
-const (
-	maxDeltas = 60
-)
-
 type adaptiveThresholdOption func(*adaptiveThreshold)
 
 func setInitialThreshold(t time.Duration) adaptiveThresholdOption {
@@ -65,16 +61,16 @@ func (a *adaptiveThreshold) compare(estimate, _ time.Duration) (usage, time.Dura
 	if a.numDeltas < 2 {
 		return usageNormal, estimate, a.max
 	}
-	t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
+
 	use := usageNormal
-	if t > a.thresh {
+	if estimate > a.thresh {
 		use = usageOver
-	} else if t < -a.thresh {
+	} else if estimate < -a.thresh {
 		use = usageUnder
 	}
 	thresh := a.thresh
-	a.update(t)
-	return use, t, thresh
+	a.update(estimate)
+	return use, estimate, thresh
 }
 
 func (a *adaptiveThreshold) update(estimate time.Duration) {

--- a/pkg/gcc/adaptive_threshold_test.go
+++ b/pkg/gcc/adaptive_threshold_test.go
@@ -104,7 +104,7 @@ func TestAdaptiveThreshold(t *testing.T) {
 			},
 			expected: []usage{usageNormal, usageOver, usageNormal},
 			options: []adaptiveThresholdOption{
-				setInitialThreshold(40 * time.Millisecond),
+				setInitialThreshold(20 * time.Millisecond),
 			},
 		},
 		{

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	chi = 0.001
+	chi   = 0.001
+	alpha = 0.95
 )
 
 type kalmanOption func(*kalman)
@@ -75,7 +76,6 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 	zms := float64(z.Microseconds()) / 1000.0
 
 	if !k.disableMeasurementUncertaintyUpdates {
-		alpha := math.Pow((1 - chi), 30.0/(1000.0*5*float64(time.Millisecond)))
 		root := math.Sqrt(k.measurementUncertainty)
 		root3 := 3 * root
 		if zms > root3 {

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -80,8 +80,9 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 		root3 := 3 * root
 		if zms > root3 {
 			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*root3*root3, 1)
+		} else {
+			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 		}
-		k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 	}
 
 	estimateUncertainty := k.estimateError + k.processUncertainty

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	chi   = 0.001
-	Kcount = 10
+	chi   = 0.01
+	Kcount = 25
 )
 
 type kalmanOption func(*kalman)
@@ -114,7 +114,7 @@ func (k *kalman) updateEstimate(measurement, lastReceiveDelta time.Duration) tim
 	}
 
 	estimateUncertainty := k.estimateError + k.processUncertainty
-	k.gain = estimateUncertainty / (estimateUncertainty + k.measurementUncertainty)
+	k.gain = math.Max(estimateUncertainty / (estimateUncertainty + k.measurementUncertainty), 0.01)
 
 	k.estimate += time.Duration(k.gain * zms * float64(time.Millisecond))
 

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	chi   = 0.001
-	alpha = 0.95
+	Kcount = 10
 )
 
 type kalmanOption func(*kalman)
@@ -21,7 +21,9 @@ type kalman struct {
 	processUncertainty     float64 // Q_i
 	estimateError          float64
 	measurementUncertainty float64
-
+	K                      [Kcount] time.Duration
+	Kmin                   time.Duration
+	kIndex                 int
 	disableMeasurementUncertaintyUpdates bool
 }
 
@@ -70,12 +72,36 @@ func newKalman(opts ...kalmanOption) *kalman {
 	return k
 }
 
-func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
+func (k *kalman) updateEstimate(measurement, lastReceiveDelta time.Duration) time.Duration {
 	z := measurement - k.estimate
 
 	zms := float64(z.Microseconds()) / 1000.0
 
 	if !k.disableMeasurementUncertaintyUpdates {
+		index:= k.kIndex % Kcount
+
+
+		if k.kIndex == 0 {
+			k.Kmin = lastReceiveDelta
+		} else if lastReceiveDelta < k.Kmin {
+			k.Kmin = lastReceiveDelta
+		} else if k.kIndex >= Kcount && k.K[index] == k.Kmin {
+			k.Kmin = lastReceiveDelta
+
+			for i:= 0; i < k.kIndex && i < Kcount; i++ {
+				if i != index && k.Kmin > k.K[i] {
+					k.Kmin = k.K[i]
+				}
+			}
+		}
+
+		k.K[index] = lastReceiveDelta
+
+		kMinms := float64(k.Kmin.Microseconds()) / 1000.0
+
+		fmax:= 1 / kMinms
+
+		alpha := math.Pow((1 - chi), 30.0/(1000.0 * fmax))
 		root := math.Sqrt(k.measurementUncertainty)
 		root3 := 3 * root
 		if zms > root3 {
@@ -83,6 +109,8 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 		} else {
 			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 		}
+
+		k.kIndex++
 	}
 
 	estimateUncertainty := k.estimateError + k.processUncertainty

--- a/pkg/gcc/kalman_test.go
+++ b/pkg/gcc/kalman_test.go
@@ -63,7 +63,7 @@ func TestKalman(t *testing.T) {
 			k := newKalman(append(tc.opts, setDisableMeasurementUncertaintyUpdates(true))...)
 			estimates := []time.Duration{}
 			for _, m := range tc.measurements {
-				estimates = append(estimates, k.updateEstimate(m))
+				estimates = append(estimates, k.updateEstimate(m, 5*time.Millisecond))
 			}
 			assert.Equal(t, tc.expected, estimates, "%v != %v", tc.expected, estimates)
 		})

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -45,7 +45,7 @@ func (a *exponentialMovingAverage) update(value float64) {
 	} else {
 		x := value - a.average
 		a.average += decreaseEMAAlpha * x
-		a.variance = (1 - decreaseEMAAlpha) * (a.variance + decreaseEMAAlpha*x*x)
+		a.variance = decreaseEMAAlpha*x*x + (1-decreaseEMAAlpha)*a.variance
 		a.stdDeviation = math.Sqrt(a.variance)
 	}
 }

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -34,20 +34,35 @@ type rateController struct {
 }
 
 type exponentialMovingAverage struct {
+	init         bool
 	average      float64
 	variance     float64
 	stdDeviation float64
+	lastUpdate   time.Time
+}
+
+func (a *exponentialMovingAverage) reset() {
+	a.init = false
+	a.average = 0
+	a.variance = 0
+	a.stdDeviation = 0
 }
 
 func (a *exponentialMovingAverage) update(value float64) {
-	if a.average == 0.0 {
+	if !a.init {
 		a.average = value
+		a.init = true
 	} else {
 		x := value - a.average
 		a.average += decreaseEMAAlpha * x
 		a.variance = decreaseEMAAlpha*x*x + (1-decreaseEMAAlpha)*a.variance
 		a.stdDeviation = math.Sqrt(a.variance)
 	}
+	a.lastUpdate = time.Now()
+}
+
+func (a *exponentialMovingAverage) expired(now time.Time) bool {
+	return a.init && now.Sub(a.lastUpdate) > time.Minute
 }
 
 func newRateController(now now, initialTargetBitrate, minBitrate, maxBitrate int, dsw func(DelayStats)) *rateController {
@@ -134,7 +149,16 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 }
 
 func (c *rateController) increase(now time.Time) int {
-	if c.latestDecreaseRate.average > 0 && float64(c.latestReceivedRate) > c.latestDecreaseRate.average-3*c.latestDecreaseRate.stdDeviation &&
+	if c.latestDecreaseRate.init &&
+		float64(c.latestReceivedRate) > c.latestDecreaseRate.average+3*c.latestDecreaseRate.stdDeviation {
+		c.latestDecreaseRate.reset()
+	}
+
+	if c.latestDecreaseRate.expired(now) {
+		c.latestDecreaseRate.reset()
+	}
+
+	if c.latestDecreaseRate.init && float64(c.latestReceivedRate) > c.latestDecreaseRate.average-3*c.latestDecreaseRate.stdDeviation &&
 		float64(c.latestReceivedRate) < c.latestDecreaseRate.average+3*c.latestDecreaseRate.stdDeviation {
 		bitsPerFrame := float64(c.target) / 30.0
 		packetsPerFrame := math.Ceil(bitsPerFrame / (1200 * 8))

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -104,7 +104,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 	case stateHold:
 		// should never occur due to check above, but makes the linter happy
 	case stateIncrease:
-		c.target = clampInt(c.increase(now), c.minBitrate, c.maxBitrate)
+		c.target = clampInt(c.increase(now), c.target, c.maxBitrate)
 		next = DelayStats{
 			Measurement:      c.delayStats.Measurement,
 			Estimate:         c.delayStats.Estimate,

--- a/pkg/gcc/slope_estimator.go
+++ b/pkg/gcc/slope_estimator.go
@@ -11,6 +11,12 @@ type estimator interface {
 	updateEstimate(measurement, lastReceiveDelta time.Duration) time.Duration
 }
 
+type estimatorFunc func(time.Duration, time.Duration) time.Duration
+
+func (f estimatorFunc) updateEstimate(d, c time.Duration) time.Duration {
+	return f(d, c)
+}
+
 type slopeEstimator struct {
 	estimator
 	init             bool

--- a/pkg/gcc/slope_estimator.go
+++ b/pkg/gcc/slope_estimator.go
@@ -8,13 +8,7 @@ import (
 )
 
 type estimator interface {
-	updateEstimate(measurement time.Duration) time.Duration
-}
-
-type estimatorFunc func(time.Duration) time.Duration
-
-func (f estimatorFunc) updateEstimate(d time.Duration) time.Duration {
-	return f(d)
+	updateEstimate(measurement, lastReceiveDelta time.Duration) time.Duration
 }
 
 type slopeEstimator struct {
@@ -42,7 +36,7 @@ func (e *slopeEstimator) onArrivalGroup(ag arrivalGroup) {
 	e.group = ag
 	e.delayStatsWriter(DelayStats{
 		Measurement:      measurement,
-		Estimate:         e.updateEstimate(measurement),
+		Estimate:         e.updateEstimate(measurement, delta),
 		Threshold:        0,
 		LastReceiveDelta: delta,
 		Usage:            0,

--- a/pkg/gcc/slope_estimator_test.go
+++ b/pkg/gcc/slope_estimator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func identity(d time.Duration) time.Duration {
+func identity(d, _ time.Duration) time.Duration {
 	return d
 }
 


### PR DESCRIPTION
#### Description
calculate fmax for Kalman filter as stated in standard.
Kalman filter stats returning sensitive estimate and we don't need to multiply it with 60.
Kalman gain should not fall lower than minimal value or filter become very insensitive to z(i).
Set Kalman chi to chi to make it more sensitive to input and react faster.
Fix exponentialMovingAverage variance calculation for rate controller.
Reset latestDecreaseRate for rate controller as standard states.
Reset latestDecreaseRate if last decrease was more than a minute ago. In this case latestDecreaseRate in inaccurate in anyway.
Merge https://github.com/pion/interceptor/pull/221 to prevent bandwidth decrease in increase state in last decrease was recently.
Removed not used 'type estimatorFunc'  

There are not fixed tests exists. If my work appreciated and tend to be accepted I will fix all tests as well. I need to know whether anybody want to review these changes.
Right now I was able to fix everything I was able to find.
@mengelbart, @Sean-Der  please take a look or point me to somebody I can review this work.
I spend several weeks trying to understand and fix this BWE. I'm not sure I understand everything but enough to pay attention to this effort. Please let me know if gcc in Pion is important, supported component   

#### Reference issue
Fixes #...
