### PR TITLE
Keep only 500ms buffer items for leaky pacer

### DIFF
--- a/pkg/gcc/noop_pacer.go
+++ b/pkg/gcc/noop_pacer.go
@@ -35,6 +35,12 @@ func NewNoOpPacer() *NoOpPacer {
 func (p *NoOpPacer) SetTargetBitrate(int) {
 }
 
+// LastDroppedItems gets dropped bytes from the last call NoOp for
+// NoOp pacer.
+func (p *NoOpPacer) LastDroppedItems() uint64 {
+	return 0
+}
+
 // AddStream adds a stream and corresponding writer to the p
 func (p *NoOpPacer) AddStream(ssrc uint32, writer interceptor.RTPWriter) {
 	p.lock.Lock()

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -31,6 +31,7 @@ type Pacer interface {
 	interceptor.RTPWriter
 	AddStream(ssrc uint32, writer interceptor.RTPWriter)
 	SetTargetBitrate(int)
+	LastDroppedItems() uint64
 	Close() error
 }
 
@@ -216,6 +217,11 @@ func (e *SendSideBWE) GetTargetBitrate() int {
 	defer e.lock.Unlock()
 
 	return e.latestBitrate
+}
+
+// GetLastDroppedPacerItems returns dropped pacer items after the last call
+func (e *SendSideBWE) GetLastDroppedPacerItems() uint64 {
+	return e.pacer.LastDroppedItems()
 }
 
 // GetStats returns some internal statistics of the bandwidth estimator


### PR DESCRIPTION
Don't allow LeakyBucketPacer to grow forever in case if client produces more bitrate than BWE proposed

#### Description
Current implementation of leaky pacer expects client to strictly honor bitrate proposed by BWE. But what if client reacts slowly or has an issue in bitrate logic. Leaky pacer show keep 500ms of items and drop older items.
#### Reference issue
Fixes #...
