### PR TITLE
Shift the expected sequence number if a packet was lost

### DIFF
--- a/pkg/jitterbuffer/jitter_buffer.go
+++ b/pkg/jitterbuffer/jitter_buffer.go
@@ -212,9 +212,10 @@ func (jb *JitterBuffer) Pop() (*rtp.Packet, error) {
 	if err != nil {
 		jb.stats.underflowCount++
 		jb.emit(BufferUnderflow)
+		jb.playoutHead++
 		return nil, err
 	}
-	jb.playoutHead = (jb.playoutHead + 1)
+	jb.playoutHead++
 	jb.updateState()
 	return packet, nil
 }


### PR DESCRIPTION
#### Description
Handle the absence of the next packet
#### Reference issue
Fixes #256
