### PR TITLE
Support custom streams filter in nack interceptor

### DIFF
--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -21,6 +21,7 @@ type GeneratorInterceptorFactory struct {
 // NewInterceptor constructs a new ReceiverInterceptor
 func (g *GeneratorInterceptorFactory) NewInterceptor(_ string) (interceptor.Interceptor, error) {
 	i := &GeneratorInterceptor{
+		streamsFilter:     streamSupportNack,
 		size:              512,
 		skipLastN:         0,
 		maxNacksPerPacket: 0,
@@ -47,6 +48,7 @@ func (g *GeneratorInterceptorFactory) NewInterceptor(_ string) (interceptor.Inte
 // GeneratorInterceptor interceptor generates nack feedback messages.
 type GeneratorInterceptor struct {
 	interceptor.NoOp
+	streamsFilter     func(info *interceptor.StreamInfo) bool
 	size              uint16
 	skipLastN         uint16
 	maxNacksPerPacket uint16
@@ -86,7 +88,7 @@ func (n *GeneratorInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) int
 // BindRemoteStream lets you modify any incoming RTP packets. It is called once for per RemoteStream. The returned method
 // will be called once per rtp packet.
 func (n *GeneratorInterceptor) BindRemoteStream(info *interceptor.StreamInfo, reader interceptor.RTPReader) interceptor.RTPReader {
-	if !streamSupportNack(info) {
+	if !n.streamsFilter(info) {
 		return reader
 	}
 

--- a/pkg/nack/generator_option.go
+++ b/pkg/nack/generator_option.go
@@ -6,6 +6,7 @@ package nack
 import (
 	"time"
 
+	"github.com/pion/interceptor"
 	"github.com/pion/logging"
 )
 
@@ -51,6 +52,14 @@ func GeneratorLog(log logging.LeveledLogger) GeneratorOption {
 func GeneratorInterval(interval time.Duration) GeneratorOption {
 	return func(r *GeneratorInterceptor) error {
 		r.interval = interval
+		return nil
+	}
+}
+
+// GeneratorStreamsFilter sets filter for generator streams
+func GeneratorStreamsFilter(filter func(info *interceptor.StreamInfo) bool) GeneratorOption {
+	return func(r *GeneratorInterceptor) error {
+		r.streamsFilter = filter
 		return nil
 	}
 }

--- a/pkg/nack/responder_option.go
+++ b/pkg/nack/responder_option.go
@@ -3,7 +3,10 @@
 
 package nack
 
-import "github.com/pion/logging"
+import (
+	"github.com/pion/interceptor"
+	"github.com/pion/logging"
+)
 
 // ResponderOption can be used to configure ResponderInterceptor
 type ResponderOption func(s *ResponderInterceptor) error
@@ -30,6 +33,14 @@ func ResponderLog(log logging.LeveledLogger) ResponderOption {
 func DisableCopy() ResponderOption {
 	return func(s *ResponderInterceptor) error {
 		s.packetFactory = &noOpPacketFactory{}
+		return nil
+	}
+}
+
+// ResponderStreamsFilter sets filter for local streams
+func ResponderStreamsFilter(filter func(info *interceptor.StreamInfo) bool) ResponderOption {
+	return func(r *ResponderInterceptor) error {
+		r.streamsFilter = filter
 		return nil
 	}
 }


### PR DESCRIPTION
#### Description

This change allows users to pass custom stream filters to the nack interceptor in order to enable/disable nacks for certain streams based on the StreamInfo.