### PR TITLE
Fix race in a03526d8eb82

### DIFF
--- a/pkg/nack/retainable_packet.go
+++ b/pkg/nack/retainable_packet.go
@@ -4,6 +4,7 @@
 package nack
 
 import (
+	"encoding/binary"
 	"io"
 	"sync"
 
@@ -13,8 +14,9 @@ import (
 const maxPayloadLen = 1460
 
 type packetManager struct {
-	headerPool  *sync.Pool
-	payloadPool *sync.Pool
+	headerPool   *sync.Pool
+	payloadPool  *sync.Pool
+	rtxSequencer rtp.Sequencer
 }
 
 func newPacketManager() *packetManager {
@@ -30,16 +32,18 @@ func newPacketManager() *packetManager {
 				return &buf
 			},
 		},
+		rtxSequencer: rtp.NewRandomSequencer(),
 	}
 }
 
-func (m *packetManager) NewPacket(header *rtp.Header, payload []byte) (*retainablePacket, error) {
+func (m *packetManager) NewPacket(header *rtp.Header, payload []byte, rtxSsrc uint32, rtxPayloadType uint8) (*retainablePacket, error) {
 	if len(payload) > maxPayloadLen {
 		return nil, io.ErrShortBuffer
 	}
 
 	p := &retainablePacket{
-		onRelease: m.releasePacket,
+		onRelease:      m.releasePacket,
+		sequenceNumber: header.SequenceNumber,
 		// new packets have retain count of 1
 		count: 1,
 	}
@@ -62,6 +66,29 @@ func (m *packetManager) NewPacket(header *rtp.Header, payload []byte) (*retainab
 		p.payload = (*p.buffer)[:size]
 	}
 
+	if rtxSsrc != 0 && rtxPayloadType != 0 {
+		// Store the original sequence number and rewrite the sequence number.
+		originalSequenceNumber := p.header.SequenceNumber
+		p.header.SequenceNumber = m.rtxSequencer.NextSequenceNumber()
+
+		// Rewrite the SSRC.
+		p.header.SSRC = rtxSsrc
+		// Rewrite the payload type.
+		p.header.PayloadType = rtxPayloadType
+
+		// Remove padding if present.
+		paddingLength := 0
+		if p.header.Padding {
+			paddingLength = int(p.payload[len(p.payload)-1])
+			p.header.Padding = false
+		}
+
+		// Write the original sequence number at the beginning of the payload.
+		payload := make([]byte, 2)
+		binary.BigEndian.PutUint16(payload, originalSequenceNumber)
+		p.payload = append(payload, p.payload[:len(p.payload)-paddingLength]...)
+	}
+
 	return p, nil
 }
 
@@ -74,12 +101,13 @@ func (m *packetManager) releasePacket(header *rtp.Header, payload *[]byte) {
 
 type noOpPacketFactory struct{}
 
-func (f *noOpPacketFactory) NewPacket(header *rtp.Header, payload []byte) (*retainablePacket, error) {
+func (f *noOpPacketFactory) NewPacket(header *rtp.Header, payload []byte, _ uint32, _ uint8) (*retainablePacket, error) {
 	return &retainablePacket{
-		onRelease: f.releasePacket,
-		count:     1,
-		header:    header,
-		payload:   payload,
+		onRelease:      f.releasePacket,
+		count:          1,
+		header:         header,
+		payload:        payload,
+		sequenceNumber: header.SequenceNumber,
 	}, nil
 }
 
@@ -96,6 +124,8 @@ type retainablePacket struct {
 	header  *rtp.Header
 	buffer  *[]byte
 	payload []byte
+
+	sequenceNumber uint16
 }
 
 func (p *retainablePacket) Header() *rtp.Header {

--- a/pkg/nack/send_buffer.go
+++ b/pkg/nack/send_buffer.go
@@ -46,7 +46,7 @@ func (s *sendBuffer) add(packet *retainablePacket) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	seq := packet.Header().SequenceNumber
+	seq := packet.sequenceNumber
 	if !s.started {
 		s.packets[seq%s.size] = packet
 		s.lastAdded = seq
@@ -92,7 +92,7 @@ func (s *sendBuffer) get(seq uint16) *retainablePacket {
 
 	pkt := s.packets[seq%s.size]
 	if pkt != nil {
-		if pkt.Header().SequenceNumber != seq {
+		if pkt.sequenceNumber != seq {
 			return nil
 		}
 		// already released

--- a/pkg/nack/send_buffer_test.go
+++ b/pkg/nack/send_buffer_test.go
@@ -21,7 +21,7 @@ func TestSendBuffer(t *testing.T) {
 		add := func(nums ...uint16) {
 			for _, n := range nums {
 				seq := start + n
-				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil)
+				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil, 0, 0)
 				require.NoError(t, err)
 				sb.add(pkt)
 			}
@@ -78,7 +78,7 @@ func TestSendBuffer_Overridden(t *testing.T) {
 	require.Equal(t, uint16(1), sb.size)
 
 	originalBytes := []byte("originalContent")
-	pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: 1}, originalBytes)
+	pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: 1}, originalBytes, 0, 0)
 	require.NoError(t, err)
 	sb.add(pkt)
 
@@ -91,7 +91,7 @@ func TestSendBuffer_Overridden(t *testing.T) {
 	require.Equal(t, 1, retrieved.count)
 
 	// ensure original packet is released
-	pkt, err = pm.NewPacket(&rtp.Header{SequenceNumber: 2}, originalBytes)
+	pkt, err = pm.NewPacket(&rtp.Header{SequenceNumber: 2}, originalBytes, 0, 0)
 	require.NoError(t, err)
 	sb.add(pkt)
 	require.Equal(t, 0, retrieved.count)
@@ -113,7 +113,7 @@ func TestSendBuffer_Race(t *testing.T) {
 		add := func(nums ...uint16) {
 			for _, n := range nums {
 				seq := start + n
-				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil)
+				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil, 0, 0)
 				require.NoError(t, err)
 				sb.add(pkt)
 			}


### PR DESCRIPTION
Modify packets before adding them to NACK buffer.

WARNING: DATA RACE
Read at 0x00c00056d456 by goroutine 10741:
  github.com/pion/interceptor/pkg/nack.(*sendBuffer).get()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/send_buffer.go:95 +0x1e4
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).resendPackets.func1()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:153 +0x70
  github.com/pion/rtcp.(*NackPair).Range()
      /home/runner/go/pkg/mod/github.com/pion/rtcp@v1.2.14/transport_layer_nack.go:65 +0x43
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).resendPackets()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:152 +0x124
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).BindRTCPReader.func1.gowrap1()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:100 +0x44

Previous write at 0x00c00056d456 by goroutine 10735:
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).resendPackets.func1()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:186 +0x684
  github.com/pion/rtcp.(*NackPair).Range()
      /home/runner/go/pkg/mod/github.com/pion/rtcp@v1.2.14/transport_layer_nack.go:65 +0x43
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).resendPackets()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:152 +0x124
  github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).BindRTCPReader.func1.gowrap1()
      /home/runner/go/pkg/mod/github.com/pion/interceptor@v0.1.35/pkg/nack/responder_interceptor.go:100 +0x44

#### Description

#### Reference issue
Fixes #...
