### PR TITLE
Fix payload size zero cause runtime panic on calculating padding size

### DIFF
--- a/pkg/nack/retainable_packet.go
+++ b/pkg/nack/retainable_packet.go
@@ -78,7 +78,7 @@ func (m *packetManager) NewPacket(header *rtp.Header, payload []byte, rtxSsrc ui
 
 		// Remove padding if present.
 		paddingLength := 0
-		if p.header.Padding {
+		if p.header.Padding && p.payload != nil && len(p.payload) > 0 {
 			paddingLength = int(p.payload[len(p.payload)-1])
 			p.header.Padding = false
 		}


### PR DESCRIPTION
I got runtime panic from [this line](https://github.com/pion/interceptor/blob/bfda3e00334428a1192adb1773f2c408799713f5/pkg/nack/retainable_packet.go#L82) when calculating the padding size but the payload size is zero.  

My code is a simple WHIP WHEP but using NACK through `webrtc.NewPeerConnection()`. This is happen when a browser publish a stream to WHIP endpoint and another browser trying to subscribe using WHEP.

```
Exception has occurred: panic
"runtime error: index out of range [-1]"
Stack:
	 3  0x0000000102a8d4d8 in github.com/pion/interceptor/pkg/nack.(*packetManager).NewPacket
	     at /Users/tyohan/go/pkg/mod/github.com/pion/interceptor@v0.1.36/pkg/nack/retainable_packet.go:82
	 4  0x0000000102a8c4b8 in github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).BindLocalStream.func1
	     at /Users/tyohan/go/pkg/mod/github.com/pion/interceptor@v0.1.36/pkg/nack/responder_interceptor.go:118
	 5  0x000000010290f3ac in github.com/pion/interceptor.RTPWriterFunc.Write
	     at /Users/tyohan/go/pkg/mod/github.com/pion/interceptor@v0.1.36/interceptor.go:86
	 6  0x0000000102a92d60 in github.com/pion/interceptor/pkg/report.(*SenderInterceptor).BindLocalStream.func1
	     at /Users/tyohan/go/pkg/mod/github.com/pion/interceptor@v0.1.36/pkg/report/sender_interceptor.go:144
	 7  0x000000010290f3ac in github.com/pion/interceptor.RTPWriterFunc.Write
	     at /Users/tyohan/go/pkg/mod/github.com/pion/interceptor@v0.1.36/interceptor.go:86
	 8  0x0000000102abcba0 in github.com/pion/webrtc/v4.(*interceptorToTrackLocalWriter).WriteRTP
	     at /Users/tyohan/go/pkg/mod/github.com/pion/webrtc/v4@v4.0.0-beta.32/interceptor.go:147
	 9  0x0000000102afd244 in github.com/pion/webrtc/v4.(*TrackLocalStaticRTP).writeRTP
	     at /Users/tyohan/go/pkg/mod/github.com/pion/webrtc/v4@v4.0.0-beta.32/track_local_static.go:172
	10  0x0000000102afd4d0 in github.com/pion/webrtc/v4.(*TrackLocalStaticRTP).Write
	     at /Users/tyohan/go/pkg/mod/github.com/pion/webrtc/v4@v4.0.0-beta.32/track_local_static.go:193
	11  0x0000000102b0e3a0 in inlive.dev/live/internal/channel.NewRemoteTrack.func1
	     at /Users/tyohan/Dev/inLive/live/internal/channel/remotetrack.go:60
```

This PR will fix the issue
