### PR TITLE
Increment rtx rtp packet sequence number only when trasmitted

### DIFF
--- a/internal/rtpbuffer/packet_factory.go
+++ b/internal/rtpbuffer/packet_factory.go
@@ -17,7 +17,6 @@ const rtxSsrcByteLength = 2
 // The NoOpPacketFactory doesn't copy packets, while the RetainablePacket will take a copy before adding
 type PacketFactory interface {
 	NewPacket(header *rtp.Header, payload []byte, rtxSsrc uint32, rtxPayloadType uint8) (*RetainablePacket, error)
-	FillSequenceNumber(packet *RetainablePacket)
 }
 
 // PacketFactoryCopy is PacketFactory that takes a copy of packets when added to the RTPBuffer
@@ -106,10 +105,6 @@ func (m *PacketFactoryCopy) NewPacket(header *rtp.Header, payload []byte, rtxSsr
 	return p, nil
 }
 
-func (m *PacketFactoryCopy) FillSequenceNumber(packet *RetainablePacket) {
-	packet.header.SequenceNumber = m.rtxSequencer.NextSequenceNumber()
-}
-
 func (m *PacketFactoryCopy) releasePacket(header *rtp.Header, payload *[]byte) {
 	m.headerPool.Put(header)
 	if payload != nil {
@@ -129,9 +124,6 @@ func (f *PacketFactoryNoOp) NewPacket(header *rtp.Header, payload []byte, _ uint
 		payload:        payload,
 		sequenceNumber: header.SequenceNumber,
 	}, nil
-}
-
-func (m *PacketFactoryNoOp) FillSequenceNumber(packet *RetainablePacket) {
 }
 
 func (f *PacketFactoryNoOp) releasePacket(_ *rtp.Header, _ *[]byte) {

--- a/pkg/nack/responder_interceptor_test.go
+++ b/pkg/nack/responder_interceptor_test.go
@@ -76,12 +76,16 @@ func TestResponderInterceptor(t *testing.T) {
 					},
 				},
 			})
-
+			expectedSequenceNumber := uint16(0)
 			// seq number 13 was never sent, so it can't be resent
-			for _, seqNum := range []uint16{11, 12, 15} {
+			for range []uint16{11, 12, 15} {
 				select {
 				case p := <-stream.WrittenRTP():
-					require.Equal(t, seqNum, p.SequenceNumber)
+					if expectedSequenceNumber == 0 {
+						expectedSequenceNumber = p.SequenceNumber
+					}
+					require.Equal(t, expectedSequenceNumber, p.SequenceNumber)
+					expectedSequenceNumber++
 				case <-time.After(10 * time.Millisecond):
 					t.Fatal("written rtp packet not found")
 				}


### PR DESCRIPTION
#### Fix for wrong sequence numbers
Currently the nack responder ([responder_interceptor.go](https://github.com/pion/interceptor/blob/master/pkg/nack/responder_interceptor.go)) generates RTX RTP packet which has not right sequence numbers. It does not increment the sequence number by one according to RFC [rfc4588](https://www.rfc-editor.org/rfc/rfc4588)

> For either multiplexing scheme, the sequence number has the standard definition; i.e., it MUST be one higher than the sequence number of the preceding packet sent in the retransmission stream.


I am proposing fix for it and appreciate any feedback as this is my first pull request in GO lang. 
