### PR TITLE
gcc: fix missing if-else in kalman

### DIFF
--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -80,8 +80,9 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 		root3 := 3 * root
 		if zms > root3 {
 			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*root3*root3, 1)
+		} else {
+			k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 		}
-		k.measurementUncertainty = math.Max(alpha*k.measurementUncertainty+(1-alpha)*zms*zms, 1)
 	}
 
 	estimateUncertainty := k.estimateError + k.processUncertainty


### PR DESCRIPTION
#### Description
Fixes a deviation from the GCC rfc spec.

#### Reference issue
Fixes #286 
