### PR TITLE
Fixed typo in string method

### DIFF
--- a/internal/cc/acknowledgment.go
+++ b/internal/cc/acknowledgment.go
@@ -23,7 +23,7 @@ type Acknowledgment struct {
 
 func (a Acknowledgment) String() string {
 	s := "ACK:\n"
-	s += fmt.Sprintf("\tTLCC:\t%v\n", a.SequenceNumber)
+	s += fmt.Sprintf("\tTWCC:\t%v\n", a.SequenceNumber)
 	s += fmt.Sprintf("\tSIZE:\t%v\n", a.Size)
 	s += fmt.Sprintf("\tDEPARTURE:\t%v\n", int64(float64(a.Departure.UnixNano())/1e+6))
 	s += fmt.Sprintf("\tARRIVAL:\t%v\n", int64(float64(a.Arrival.UnixNano())/1e+6))


### PR DESCRIPTION
#### Description
Fixed a typo which I noticed while reading the code.
