### PR TITLE
Fix nack buffer RTX issue

### DIFF
--- a/internal/rtpbuffer/rtpbuffer_test.go
+++ b/internal/rtpbuffer/rtpbuffer_test.go
@@ -124,6 +124,10 @@ func TestRTPBuffer_WithRTX(t *testing.T) {
 		assertGet(10)
 		assertNOTGet(1, 2, 9)
 
+		// A late packet coming in (such as due to RTX) shouldn't invalidate other packets.
+		add(9)
+		assertGet(3, 4, 5, 6, 7, 8, 9, 10)
+
 		add(22)
 		assertGet(22)
 		assertNOTGet(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)


### PR DESCRIPTION
There was previously an issue with the nack buffer that would occur when an uploader was experiencing packet loss (or otherwise had reordering occur). `lastAdded` was getting set for every packet added to the buffer, but packets could get added out of order, causing `lastAdded` to go backwards. The impact was that packets at the end of the buffer were sometimes considered stale and cleared out. Consider the following sequence of packets being added to the buffer:

1, 2, 4, 3, 5, ...

When 4 is added, `lastAdded` would correctly be 4, but then when 3 arrived, `lastAdded` would go backwards to 3. This would cause two related problems: trying to get 4 from the buffer would fail (`uint16(3 - 4) > Uint16SizeHalf`), and then when we add 5, we would treat 4 as a gap between `lastAdded` (3) and `seq` (5) and thus release 4 from the buffer, such that even after 5 was added, we would still not be able to retrieve 4 from the buffer.

This PR modifies the logic to only move `lastAdded` forward if `diff` is "positive" (less than `Uint16SizeHalf`), meaning the new packet is newer than any packet received previously.
