### PR TITLE
Move NTP function to ntp package and add ToTime32

### DIFF
--- a/pkg/rfc8888/recorder.go
+++ b/pkg/rfc8888/recorder.go
@@ -6,6 +6,7 @@ package rfc8888
 import (
 	"time"
 
+	"github.com/pion/interceptor/internal/ntp"
 	"github.com/pion/rtcp"
 )
 
@@ -44,7 +45,7 @@ func (r *Recorder) BuildReport(now time.Time, maxSize int) *rtcp.CCFeedbackRepor
 	report := &rtcp.CCFeedbackReport{
 		SenderSSRC:      r.ssrc,
 		ReportBlocks:    []rtcp.CCFeedbackReportBlock{},
-		ReportTimestamp: ntpTime32(now),
+		ReportTimestamp: ntp.ToNTP32(now),
 	}
 
 	maxReportBlocks := (maxSize - 12 - (8 * len(r.streams))) / 2
@@ -64,15 +65,4 @@ func (r *Recorder) BuildReport(now time.Time, maxSize int) *rtcp.CCFeedbackRepor
 	}
 
 	return report
-}
-
-func ntpTime32(t time.Time) uint32 {
-	// seconds since 1st January 1900
-	s := (float64(t.UnixNano()) / 1000000000.0) + 2208988800
-
-	integerPart := uint32(s)
-	fractionalPart := uint32((s - float64(integerPart)) * 0xFFFFFFFF)
-
-	// higher 32 bits are the integer part, lower 32 bits are the fractional part
-	return uint32(((uint64(integerPart)<<32 | uint64(fractionalPart)) >> 16) & 0xFFFFFFFF)
 }

--- a/pkg/rfc8888/recorder_test.go
+++ b/pkg/rfc8888/recorder_test.go
@@ -4,7 +4,6 @@
 package rfc8888
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -160,39 +159,4 @@ func TestRecorder(t *testing.T) {
 			assert.Less(t, 3, len(reports.ReportBlocks[i].MetricBlocks))
 		}
 	})
-}
-
-func TestNTPTime32(t *testing.T) {
-	zero := time.Date(1900, time.January, 1, 0, 0, 0, 0, time.UTC)
-	notSoLongAgo := time.Date(2022, time.May, 5, 14, 48, 20, 0, time.UTC)
-	for i, cc := range []struct {
-		input    time.Time
-		expected uint32
-	}{
-		{
-			input:    zero,
-			expected: 0,
-		},
-		{
-			input:    zero.Add(time.Second),
-			expected: 1 << 16,
-		},
-		{
-			input:    notSoLongAgo,
-			expected: uint32(uint(notSoLongAgo.Sub(zero).Seconds())&0xffff) << 16,
-		},
-		{
-			input:    zero.Add(400 * time.Millisecond),
-			expected: 26214,
-		},
-		{
-			input:    zero.Add(1400 * time.Millisecond),
-			expected: 1<<16 + 26214,
-		},
-	} {
-		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			res := ntpTime32(cc.input)
-			assert.Equalf(t, cc.expected, res, "%b != %b", cc.expected, res)
-		})
-	}
 }


### PR DESCRIPTION
Moves all NTP-related functions to the NTP package and adds a function to recover a time.Time from a uint32 encoded NTP timestamp. This allows reusing code for CCFB handling (and testing).