### PR TITLE
Binary formatters in packetdump

### DIFF
--- a/pkg/packetdump/filter.go
+++ b/pkg/packetdump/filter.go
@@ -14,4 +14,9 @@ type RTPFilterCallback func(pkt *rtp.Packet) bool
 
 // RTCPFilterCallback can be used to filter RTCP packets to dump.
 // The callback returns whether or not to print dump the packet's content.
+// Deprecated: prefer RTCPFilterPerPacketCallback
 type RTCPFilterCallback func(pkt []rtcp.Packet) bool
+
+// RTCPFilterPerPacketCallback can be used to filter RTCP packets to dump.
+// It's called once per every packet opposing to RTCPFilterCallback which is called once per packet batch
+type RTCPFilterPerPacketCallback func(pkt rtcp.Packet) bool

--- a/pkg/packetdump/filter.go
+++ b/pkg/packetdump/filter.go
@@ -14,9 +14,9 @@ type RTPFilterCallback func(pkt *rtp.Packet) bool
 
 // RTCPFilterCallback can be used to filter RTCP packets to dump.
 // The callback returns whether or not to print dump the packet's content.
-// Deprecated: prefer RTCPFilterPerPacketCallback
+// Deprecated: prefer RTCPPerPacketFilterCallback
 type RTCPFilterCallback func(pkt []rtcp.Packet) bool
 
-// RTCPFilterPerPacketCallback can be used to filter RTCP packets to dump.
+// RTCPPerPacketFilterCallback can be used to filter RTCP packets to dump.
 // It's called once per every packet opposing to RTCPFilterCallback which is called once per packet batch
-type RTCPFilterPerPacketCallback func(pkt rtcp.Packet) bool
+type RTCPPerPacketFilterCallback func(pkt rtcp.Packet) bool

--- a/pkg/packetdump/format.go
+++ b/pkg/packetdump/format.go
@@ -14,19 +14,29 @@ import (
 // RTPFormatCallback can be used to apply custom formatting to each dumped RTP
 // packet. If new lines should be added after each packet, they must be included
 // in the returned format.
+// Deprecated: prefer RTPBinaryFormatCallback
 type RTPFormatCallback func(*rtp.Packet, interceptor.Attributes) string
 
 // RTCPFormatCallback can be used to apply custom formatting to each dumped RTCP
 // packet. If new lines should be added after each packet, they must be included
 // in the returned format.
+// Deprecated: prefer RTCPBinaryFormatCallback
 type RTCPFormatCallback func([]rtcp.Packet, interceptor.Attributes) string
 
 // DefaultRTPFormatter returns the default log format for RTP packets
+// Deprecated: useless export since set by default
 func DefaultRTPFormatter(pkt *rtp.Packet, _ interceptor.Attributes) string {
 	return fmt.Sprintf("%s\n", pkt)
 }
 
 // DefaultRTCPFormatter returns the default log format for RTCP packets
+// Deprecated: useless export since set by default
 func DefaultRTCPFormatter(pkts []rtcp.Packet, _ interceptor.Attributes) string {
 	return fmt.Sprintf("%s\n", pkts)
 }
+
+// RTPBinaryFormatCallback can be used to apply custom formatting or marshaling to each dumped RTP packet
+type RTPBinaryFormatCallback func(*rtp.Packet, interceptor.Attributes) ([]byte, error)
+
+// RTCPBinaryFormatCallback can be used to apply custom formatting or marshaling to each dumped RTCP packet
+type RTCPBinaryFormatCallback func(rtcp.Packet, interceptor.Attributes) ([]byte, error)

--- a/pkg/packetdump/option.go
+++ b/pkg/packetdump/option.go
@@ -37,6 +37,7 @@ func RTCPWriter(w io.Writer) PacketDumperOption {
 }
 
 // RTPFormatter sets the RTP format
+// Deprecated: prefer RTPBinaryFormatter
 func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtpFormat = f
@@ -45,9 +46,26 @@ func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 }
 
 // RTCPFormatter sets the RTCP format
+// Deprecated: prefer RTCPBinaryFormatter
 func RTCPFormatter(f RTCPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpFormat = f
+		return nil
+	}
+}
+
+// RTPBinaryFormatter sets the RTP binary formatter
+func RTPBinaryFormatter(f RTPBinaryFormatCallback) PacketDumperOption {
+	return func(d *PacketDumper) error {
+		d.rtpFormatBinary = f
+		return nil
+	}
+}
+
+// RTCPBinaryFormatter sets the RTCP binary formatter
+func RTCPBinaryFormatter(f RTCPBinaryFormatCallback) PacketDumperOption {
+	return func(d *PacketDumper) error {
+		d.rtcpFormatBinary = f
 		return nil
 	}
 }
@@ -61,9 +79,18 @@ func RTPFilter(callback RTPFilterCallback) PacketDumperOption {
 }
 
 // RTCPFilter sets the RTCP filter.
+// Deprecated: prefer RTCPFilterPerPacket
 func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpFilter = callback
+		return nil
+	}
+}
+
+// RTCPFilterPerPacket sets the RTCP per-packet filter.
+func RTCPFilterPerPacket(callback RTCPFilterPerPacketCallback) PacketDumperOption {
+	return func(d *PacketDumper) error {
+		d.rtcpFilterPerPacket = callback
 		return nil
 	}
 }

--- a/pkg/packetdump/option.go
+++ b/pkg/packetdump/option.go
@@ -79,7 +79,7 @@ func RTPFilter(callback RTPFilterCallback) PacketDumperOption {
 }
 
 // RTCPFilter sets the RTCP filter.
-// Deprecated: prefer RTCPFilterPerPacket
+// Deprecated: prefer RTCPPerPacketFilter
 func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpFilter = callback
@@ -87,10 +87,10 @@ func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	}
 }
 
-// RTCPFilterPerPacket sets the RTCP per-packet filter.
-func RTCPFilterPerPacket(callback RTCPFilterPerPacketCallback) PacketDumperOption {
+// RTCPPerPacketFilter sets the RTCP per-packet filter.
+func RTCPPerPacketFilter(callback RTCPPerPacketFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
-		d.rtcpFilterPerPacket = callback
+		d.rtcpPerPacketFilter = callback
 		return nil
 	}
 }

--- a/pkg/packetdump/receiver_interceptor_test.go
+++ b/pkg/packetdump/receiver_interceptor_test.go
@@ -108,3 +108,59 @@ func TestReceiverFilterNothing(t *testing.T) {
 
 	assert.NotZero(t, buf.Len())
 }
+
+func TestReceiverCustomBinaryFormatter(t *testing.T) {
+	rtpBuf := bytes.Buffer{}
+	rtcpBuf := bytes.Buffer{}
+
+	factory, err := NewReceiverInterceptor(
+		RTPWriter(&rtpBuf),
+		RTCPWriter(&rtcpBuf),
+		Log(logging.NewDefaultLoggerFactory().NewLogger("test")),
+		// custom binary formatter to dump only seqno mod 256
+		RTPBinaryFormatter(func(p *rtp.Packet, _ interceptor.Attributes) ([]byte, error) {
+			return []byte{byte(p.SequenceNumber)}, nil
+		}),
+		// custom binary formatter to dump only DestinationSSRCs mod 256
+		RTCPBinaryFormatter(func(p rtcp.Packet, _ interceptor.Attributes) ([]byte, error) {
+			b := make([]byte, 0)
+			for _, ssrc := range p.DestinationSSRC() {
+				b = append(b, byte(ssrc))
+			}
+			return b, nil
+		}),
+	)
+	assert.NoError(t, err)
+
+	i, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, 0, rtpBuf.Len())
+	assert.EqualValues(t, 0, rtcpBuf.Len())
+
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SSRC:      123456,
+		ClockRate: 90000,
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	stream.ReceiveRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{
+		SenderSSRC: 123,
+		MediaSSRC:  45,
+	}})
+	stream.ReceiveRTP(&rtp.Packet{Header: rtp.Header{
+		SequenceNumber: uint16(123),
+	}})
+
+	// Give time for packets to be handled and stream written to.
+	time.Sleep(50 * time.Millisecond)
+
+	err = i.Close()
+	assert.NoError(t, err)
+
+	// check that there is custom formatter results in buffer
+	assert.Equal(t, []byte{123}, rtpBuf.Bytes())
+	assert.Equal(t, []byte{45}, rtcpBuf.Bytes())
+}

--- a/pkg/packetdump/sender_interceptor_test.go
+++ b/pkg/packetdump/sender_interceptor_test.go
@@ -173,3 +173,54 @@ func TestSenderCustomBinaryFormatter(t *testing.T) {
 	assert.Equal(t, []byte{123}, rtpBuf.Bytes())
 	assert.Equal(t, []byte{45}, rtcpBuf.Bytes())
 }
+
+func TestSenderRTCPPerPacketFilter(t *testing.T) {
+	buf := bytes.Buffer{}
+
+	factory, err := NewSenderInterceptor(
+		RTCPWriter(&buf),
+		Log(logging.NewDefaultLoggerFactory().NewLogger("test")),
+		RTCPPerPacketFilter(func(packet rtcp.Packet) bool {
+			_, isPli := packet.(*rtcp.PictureLossIndication)
+			return isPli
+		}),
+		RTCPBinaryFormatter(func(p rtcp.Packet, _ interceptor.Attributes) ([]byte, error) {
+			assert.IsType(t, &rtcp.PictureLossIndication{}, p)
+			return []byte{123}, nil
+		}),
+	)
+	assert.NoError(t, err)
+
+	i, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, 0, buf.Len())
+
+	stream := test.NewMockStream(&interceptor.StreamInfo{
+		SSRC:      123456,
+		ClockRate: 90000,
+	}, i)
+	defer func() {
+		assert.NoError(t, stream.Close())
+	}()
+
+	err = stream.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{
+		SenderSSRC: 123,
+		MediaSSRC:  456,
+	}})
+	assert.NoError(t, err)
+
+	err = stream.WriteRTCP([]rtcp.Packet{&rtcp.ReceiverReport{
+		SSRC: 789,
+	}})
+	assert.NoError(t, err)
+
+	// Give time for packets to be handled and stream written to.
+	time.Sleep(50 * time.Millisecond)
+
+	err = i.Close()
+	assert.NoError(t, err)
+
+	// Only single PictureLossIndication should have been written.
+	assert.Equal(t, []byte{123}, buf.Bytes())
+}


### PR DESCRIPTION
#### Description

This PR adds new packet dumper options that let you use RTP/RTCP formatters returning `[]byte` instead of strings. This makes it easier to create dumpers that save RTP data in binary formats like PCAP. The formatter and filter APIs are also updated to handle one RTCP packet at a time, making them consistent with how RTP is handled.