### PR TITLE
Fix report timestamps

### DIFF
--- a/pkg/rfc8888/interceptor.go
+++ b/pkg/rfc8888/interceptor.go
@@ -169,7 +169,8 @@ func (s *SenderInterceptor) loop(writer interceptor.RTCPWriter) {
 			s.log.Tracef("got packet: %v", pkt)
 			s.recorder.AddPacket(pkt.arrival, pkt.ssrc, pkt.sequenceNumber, pkt.ecn)
 
-		case now := <-t.Ch():
+		case <-t.Ch():
+			now := s.now()
 			s.log.Tracef("report triggered at %v", now)
 			if writer == nil {
 				s.log.Trace("no writer added, continue")


### PR DESCRIPTION
#### Description

This is not really a bug but annoying to receivers of our reports. If the ticker ticks, but then another packet is handled first, the timestamp of the report (from the ticker) will be before the receive timestamp of the last packet in the report. In that case, the report contains a 0x1FFF value to indicate that the packet was received after the report. However, we know the timestamp and can send it, if we take the timstamp after entering the case branch. At that time, it is guaranteed, that no additional packets can be added to the report.
