### PR TITLE
Fix race in nack responder 

### DIFF
--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -105,11 +105,12 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 
 	// error is already checked in NewGeneratorInterceptor
 	rtpBuffer, _ := rtpbuffer.NewRTPBuffer(n.size)
-	n.streamsMu.Lock()
-	n.streams[info.SSRC] = &localStream{
+	stream := &localStream{
 		rtpBuffer: rtpBuffer,
 		rtpWriter: writer,
 	}
+	n.streamsMu.Lock()
+	n.streams[info.SSRC] = stream
 	n.streamsMu.Unlock()
 
 	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
@@ -122,8 +123,8 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 		if err != nil {
 			return 0, err
 		}
-		n.streams[info.SSRC].rtpBufferMutex.Lock()
-		defer n.streams[info.SSRC].rtpBufferMutex.Unlock()
+		stream.rtpBufferMutex.Lock()
+		defer stream.rtpBufferMutex.Unlock()
 
 		rtpBuffer.Add(pkt)
 


### PR DESCRIPTION
#### Description

Fixes the following panic:

```
fatal error: concurrent map read and map write 
github.com/pion/interceptor/pkg/nack.(*ResponderInterceptor).BindLocalStream.func1(0xc0b16fae10, {0xc03af93210, 0x467, 0x467}, 0xc0a8afe9c0)
github.com/pion/interceptor/pkg/nack/responder_interceptor.go:126 +0x145 github.com/pion/interceptor.RTPWriterFunc.Write
```
Looks like race was introduced in d34a3c5
