### PR TITLE
Update lint rules, force testify/assert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,14 +131,15 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands
     - path: cmd
       linters:
         - forbidigo
-  max-issues-per-linter: 0
-  max-same-issues: 0

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,6 +6,8 @@ package interceptor
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMultiError(t *testing.T) {
@@ -25,20 +27,13 @@ func TestMultiError(t *testing.T) {
 	})
 	str := "err1\nerr2\nerr3"
 
-	if errs.Error() != str {
-		t.Errorf("String representation doesn't match, expected: %s, got: %s", errs.Error(), str)
-	}
+	assert.Equal(t, str, errs.Error(), "String representation doesn't match")
 
 	errIs, ok := errs.(multiError) //nolint
-	if !ok {
-		t.Fatal("FlattenErrs returns non-multiError")
-	}
+	assert.True(t, ok, "FlattenErrs returns non-multiError")
+
 	for i := 0; i < 3; i++ {
-		if !errIs.Is(rawErrs[i]) {
-			t.Errorf("'%+v' should contains '%v'", errs, rawErrs[i])
-		}
+		assert.True(t, errIs.Is(rawErrs[i]), "Should contain error %d", i)
 	}
-	if errIs.Is(rawErrs[3]) {
-		t.Errorf("'%+v' should not contains '%v'", errs, rawErrs[3])
-	}
+	assert.False(t, errIs.Is(rawErrs[3]), "Should not contain error %d", 3)
 }

--- a/internal/rtpbuffer/rtpbuffer_test.go
+++ b/internal/rtpbuffer/rtpbuffer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,14 +36,8 @@ func TestRTPBuffer(t *testing.T) {
 			for _, n := range nums {
 				seq := start + n
 				packet := sb.Get(seq)
-				if packet == nil {
-					t.Errorf("packet not found: %d", seq)
-
-					continue
-				}
-				if packet.Header().SequenceNumber != seq {
-					t.Errorf("packet for %d returned with incorrect SequenceNumber: %d", seq, packet.Header().SequenceNumber)
-				}
+				assert.NotNil(t, packet, "packet not found: %d", seq)
+				assert.Equal(t, seq, packet.Header().SequenceNumber, "packet for %d returned with incorrect SequenceNumber", seq)
 				packet.Release()
 			}
 		}
@@ -51,9 +46,7 @@ func TestRTPBuffer(t *testing.T) {
 			for _, n := range nums {
 				seq := start + n
 				packet := sb.Get(seq)
-				if packet != nil {
-					t.Errorf("packet found for %d: %d", seq, packet.Header().SequenceNumber)
-				}
+				assert.Nil(t, packet, "packet found for %d", seq)
 			}
 		}
 
@@ -99,17 +92,14 @@ func TestRTPBuffer_WithRTX(t *testing.T) {
 			for _, n := range nums {
 				seq := start + n
 				packet := sb.Get(seq)
-				if packet == nil {
-					t.Errorf("packet not found: %d", seq)
+				assert.NotNil(t, packet, "packet not found: %d", seq)
 
-					continue
-				}
-				if packet.Header().SSRC != 1 && packet.Header().PayloadType != 1 {
-					t.Errorf(
-						"packet for %d returned with incorrect SSRC : %d and PayloadType: %d",
-						seq, packet.Header().SSRC, packet.Header().PayloadType,
-					)
-				}
+				assert.True(
+					t,
+					packet.Header().SSRC == 1 && packet.Header().PayloadType == 1,
+					"packet for %d returned with incorrect SSRC : %d and PayloadType: %d",
+					seq, packet.Header().SSRC, packet.Header().PayloadType,
+				)
 				packet.Release()
 			}
 		}
@@ -118,9 +108,7 @@ func TestRTPBuffer_WithRTX(t *testing.T) {
 			for _, n := range nums {
 				seq := start + n
 				packet := sb.Get(seq)
-				if packet != nil {
-					t.Errorf("packet found for %d: %d", seq, packet.Header().SequenceNumber)
-				}
+				assert.Nil(t, packet, "packet found for %d", seq)
 			}
 		}
 

--- a/internal/test/mock_stream_test.go
+++ b/internal/test/mock_stream_test.go
@@ -22,11 +22,11 @@ func TestMockStream(t *testing.T) {
 	select {
 	case <-mockStream.WrittenRTCP():
 	case <-time.After(10 * time.Millisecond):
-		t.Error("rtcp packet written but not found")
+		assert.Fail(t, "rtcp packet written but not found")
 	}
 	select {
 	case <-mockStream.WrittenRTCP():
-		t.Error("single rtcp packet written, but multiple found")
+		assert.Fail(t, "single rtcp packet written, but multiple found")
 	case <-time.After(10 * time.Millisecond):
 	}
 
@@ -35,41 +35,37 @@ func TestMockStream(t *testing.T) {
 	select {
 	case <-mockStream.WrittenRTP():
 	case <-time.After(10 * time.Millisecond):
-		t.Error("rtp packet written but not found")
+		assert.Fail(t, "rtp packet written but not found")
 	}
 	select {
 	case <-mockStream.WrittenRTP():
-		t.Error("single rtp packet written, but multiple found")
+		assert.Fail(t, "single rtp packet written, but multiple found")
 	case <-time.After(10 * time.Millisecond):
 	}
 
 	mockStream.ReceiveRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{}})
 	select {
 	case r := <-mockStream.ReadRTCP():
-		if r.Err != nil {
-			t.Errorf("read rtcp returned error: %v", r.Err)
-		}
+		assert.NoError(t, r.Err, "read rtcp returned error")
 	case <-time.After(10 * time.Millisecond):
-		t.Error("rtcp packet received but not read")
+		assert.Fail(t, "rtcp packet received but not read")
 	}
 	select {
 	case r := <-mockStream.ReadRTCP():
-		t.Errorf("single rtcp packet received, but multiple read: %v", r)
+		assert.Fail(t, "single rtcp packet received, but multiple read: %v", r)
 	case <-time.After(10 * time.Millisecond):
 	}
 
 	mockStream.ReceiveRTP(&rtp.Packet{})
 	select {
 	case r := <-mockStream.ReadRTP():
-		if r.Err != nil {
-			t.Errorf("read rtcp returned error: %v", r.Err)
-		}
+		assert.NoError(t, r.Err, "read rtp returned error")
 	case <-time.After(10 * time.Millisecond):
-		t.Error("rtp packet received but not read")
+		assert.Fail(t, "rtp packet received but not read")
 	}
 	select {
 	case r := <-mockStream.ReadRTP():
-		t.Errorf("single rtp packet received, but multiple read: %v", r)
+		assert.Fail(t, "single rtp packet received, but multiple read: %v", r)
 	case <-time.After(10 * time.Millisecond):
 	}
 

--- a/pkg/mock/interceptor_test.go
+++ b/pkg/mock/interceptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/pion/interceptor"
+	"github.com/stretchr/testify/assert"
 )
 
 //nolint:cyclop
@@ -21,23 +22,25 @@ func TestInterceptor(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		testInterceptor := &Interceptor{}
 
-		if testInterceptor.BindRTCPWriter(dummyRTCPWriter) != dummyRTCPWriter {
-			t.Error("Default BindRTCPWriter should return given writer")
-		}
-		if testInterceptor.BindRTCPReader(dummyRTCPReader) != dummyRTCPReader {
-			t.Error("Default BindRTCPReader should return given reader")
-		}
-		if testInterceptor.BindLocalStream(dummyStreamInfo, dummyRTPWriter) != dummyRTPWriter {
-			t.Error("Default BindLocalStream should return given writer")
-		}
+		assert.Equal(
+			t, dummyRTCPWriter, testInterceptor.BindRTCPWriter(dummyRTCPWriter),
+			"Default BindRTCPWriter should return given writer",
+		)
+		assert.Equal(
+			t, dummyRTCPReader, testInterceptor.BindRTCPReader(dummyRTCPReader),
+			"Default BindRTCPReader should return given reader",
+		)
+		assert.Equal(
+			t, dummyRTPWriter, testInterceptor.BindLocalStream(dummyStreamInfo, dummyRTPWriter),
+			"Default BindLocalStream should return given writer",
+		)
 		testInterceptor.UnbindLocalStream(dummyStreamInfo)
-		if testInterceptor.BindRemoteStream(dummyStreamInfo, dummyRTPReader) != dummyRTPReader {
-			t.Error("Default BindRemoteStream should return given reader")
-		}
+		assert.Equal(
+			t, dummyRTPReader, testInterceptor.BindRemoteStream(dummyStreamInfo, dummyRTPReader),
+			"Default BindRemoteStream should return given writer",
+		)
 		testInterceptor.UnbindRemoteStream(dummyStreamInfo)
-		if testInterceptor.Close() != nil {
-			t.Error("Default Close should return nil")
-		}
+		assert.NoError(t, testInterceptor.Close(), "Default Close should return nil")
 	})
 	t.Run("Custom", func(t *testing.T) {
 		var (
@@ -83,44 +86,38 @@ func TestInterceptor(t *testing.T) {
 			},
 		}
 
-		if testInterceptor.BindRTCPWriter(dummyRTCPWriter) != dummyRTCPWriter {
-			t.Error("Mocked BindRTCPWriter should return given writer")
-		}
-		if testInterceptor.BindRTCPReader(dummyRTCPReader) != dummyRTCPReader {
-			t.Error("Mocked BindRTCPReader should return given reader")
-		}
-		if testInterceptor.BindLocalStream(dummyStreamInfo, dummyRTPWriter) != dummyRTPWriter {
-			t.Error("Mocked BindLocalStream should return given writer")
-		}
+		assert.Equal(
+			t, dummyRTCPWriter, testInterceptor.BindRTCPWriter(dummyRTCPWriter),
+			"Mocked BindRTCPWriter should return given writer",
+		)
+		assert.Equal(
+			t, dummyRTCPReader, testInterceptor.BindRTCPReader(dummyRTCPReader),
+			"Mocked BindRTCPReader should return given reader",
+		)
+		assert.Equal(
+			t, dummyRTPWriter, testInterceptor.BindLocalStream(dummyStreamInfo, dummyRTPWriter),
+			"Mocked BindLocalStream should return given writer",
+		)
 		testInterceptor.UnbindLocalStream(dummyStreamInfo)
-		if testInterceptor.BindRemoteStream(dummyStreamInfo, dummyRTPReader) != dummyRTPReader {
-			t.Error("Mocked BindRemoteStream should return given reader")
-		}
+		assert.Equal(
+			t, dummyRTPReader, testInterceptor.BindRemoteStream(dummyStreamInfo, dummyRTPReader),
+			"Mocked BindRemoteStream should return given writer",
+		)
 		testInterceptor.UnbindRemoteStream(dummyStreamInfo)
-		if testInterceptor.Close() != nil {
-			t.Error("Mocked Close should return nil")
-		}
+		assert.NoError(t, testInterceptor.Close(), "Mocked Close should return nil")
 
-		if cnt := atomic.LoadUint32(&cntBindRTCPWriter); cnt != 1 {
-			t.Errorf("BindRTCPWriterFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntBindRTCPReader); cnt != 1 {
-			t.Errorf("BindRTCPReaderFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntBindLocalStream); cnt != 1 {
-			t.Errorf("BindLocalStreamFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntUnbindLocalStream); cnt != 1 {
-			t.Errorf("UnbindLocalStreamFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntBindRemoteStream); cnt != 1 {
-			t.Errorf("BindRemoteStreamFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntUnbindRemoteStream); cnt != 1 {
-			t.Errorf("UnbindRemoteStreamFn is expected to be called once, but called %d times", cnt)
-		}
-		if cnt := atomic.LoadUint32(&cntClose); cnt != 1 {
-			t.Errorf("CloseFn is expected to be called once, but called %d times", cnt)
-		}
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&cntBindRTCPWriter), "BindRTCPWriterFn is expected to be called once")
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&cntBindRTCPReader), "BindRTCPReaderFn is expected to be called once")
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&cntBindLocalStream), "BindLocalStreamFn is expected to be called once")
+		assert.Equal(
+			t, uint32(1), atomic.LoadUint32(&cntUnbindLocalStream), "UnbindLocalStreamFn is expected to be called once",
+		)
+		assert.Equal(
+			t, uint32(1), atomic.LoadUint32(&cntBindRemoteStream), "BindRemoteStreamFn is expected to be called once",
+		)
+		assert.Equal(
+			t, uint32(1), atomic.LoadUint32(&cntUnbindRemoteStream), "UnbindRemoteStreamFn is expected to be called once",
+		)
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&cntClose), "CloseFn is expected to be called once")
 	})
 }

--- a/pkg/nack/generator_interceptor_test.go
+++ b/pkg/nack/generator_interceptor_test.go
@@ -44,7 +44,7 @@ func TestGeneratorInterceptor(t *testing.T) {
 			assert.NoError(t, r.Err)
 			assert.Equal(t, seqNum, r.Packet.SequenceNumber)
 		case <-time.After(50 * time.Millisecond):
-			t.Fatal("receiver rtp packet not found")
+			assert.FailNow(t, "receiver rtp packet not found")
 		}
 	}
 
@@ -67,7 +67,7 @@ func TestGeneratorInterceptor(t *testing.T) {
 		// we want packets: 13, 15 (not packet 17, because skipLastN is setReceived to 2)
 		assert.Equal(t, rtcp.PacketBitmap(0b10), p.Nacks[0].LostPackets)
 	case <-time.After(10 * time.Millisecond):
-		t.Fatal("written rtcp packet not found")
+		assert.FailNow(t, "written rtcp packet not found")
 	}
 }
 

--- a/pkg/nack/receive_log_test.go
+++ b/pkg/nack/receive_log_test.go
@@ -5,8 +5,9 @@ package nack
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //nolint:cyclop
@@ -18,9 +19,7 @@ func TestReceivedBuffer(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StartFrom%d", start), func(t *testing.T) {
 			rl, err := newReceiveLog(128)
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
+			assert.NoError(t, err)
 
 			all := func(minVal uint16, maxVal uint16) []uint16 {
 				result := make([]uint16, 0)
@@ -50,18 +49,14 @@ func TestReceivedBuffer(t *testing.T) {
 				t.Helper()
 				for _, n := range nums {
 					seq := start + n
-					if !rl.get(seq) {
-						t.Errorf("not found: %d", seq)
-					}
+					assert.True(t, rl.get(seq), "packet not found: %d", seq)
 				}
 			}
 			assertNOTGet := func(nums ...uint16) {
 				t.Helper()
 				for _, n := range nums {
 					seq := start + n
-					if rl.get(seq) {
-						t.Errorf("packet found for %d", seq)
-					}
+					assert.False(t, rl.get(seq), "packet found for %d", seq)
 				}
 			}
 			assertMissing := func(skipLastN uint16, nums []uint16) {
@@ -74,15 +69,11 @@ func TestReceivedBuffer(t *testing.T) {
 				for _, n := range nums {
 					want = append(want, start+n)
 				}
-				if !reflect.DeepEqual(want, missing) {
-					t.Errorf("missing want/got %v / %v", want, missing)
-				}
+				assert.Equal(t, want, missing, "missing packets don't match")
 			}
 			assertLastConsecutive := func(lastConsecutive uint16) {
 				want := lastConsecutive + start
-				if rl.lastConsecutive != want {
-					t.Errorf("invalid lastConsecutive want %d got %d", want, rl.lastConsecutive)
-				}
+				assert.Equal(t, want, rl.lastConsecutive, "lastConsecutive doesn't match")
 			}
 
 			add(0)

--- a/pkg/nack/responder_interceptor_test.go
+++ b/pkg/nack/responder_interceptor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,7 +65,7 @@ func TestResponderInterceptor(t *testing.T) {
 				case p := <-stream.WrittenRTP():
 					require.Equal(t, seqNum, p.SequenceNumber)
 				case <-time.After(10 * time.Millisecond):
-					t.Fatal("written rtp packet not found")
+					assert.FailNow(t, "written rtp packet not found")
 				}
 			}
 
@@ -84,13 +85,13 @@ func TestResponderInterceptor(t *testing.T) {
 				case p := <-stream.WrittenRTP():
 					require.Equal(t, seqNum, p.SequenceNumber)
 				case <-time.After(10 * time.Millisecond):
-					t.Fatal("written rtp packet not found")
+					assert.Fail(t, "written rtp packet not found")
 				}
 			}
 
 			select {
 			case p := <-stream.WrittenRTP():
-				t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
+				assert.Fail(t, "no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
 			case <-time.After(10 * time.Millisecond):
 			}
 		})
@@ -224,14 +225,14 @@ func TestResponderInterceptor_StreamFilter(t *testing.T) {
 		case p := <-streamWithoutNacks.WrittenRTP():
 			require.Equal(t, seqNum, p.SequenceNumber)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 
 		select {
 		case p := <-streamWithNacks.WrittenRTP():
 			require.Equal(t, seqNum, p.SequenceNumber)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 	}
 
@@ -258,12 +259,12 @@ func TestResponderInterceptor_StreamFilter(t *testing.T) {
 	select {
 	case <-streamWithNacks.WrittenRTP():
 	case <-time.After(10 * time.Millisecond):
-		t.Fatal("nack response expected")
+		assert.Fail(t, "nack response expected")
 	}
 
 	select {
 	case <-streamWithoutNacks.WrittenRTP():
-		t.Fatal("no nack response expected")
+		assert.Fail(t, "no nack response expected")
 	case <-time.After(10 * time.Millisecond):
 	}
 }
@@ -292,7 +293,7 @@ func TestResponderInterceptor_RFC4588(t *testing.T) {
 		case p := <-stream.WrittenRTP():
 			require.Equal(t, seqNum, p.SequenceNumber)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 	}
 
@@ -314,13 +315,13 @@ func TestResponderInterceptor_RFC4588(t *testing.T) {
 			require.Equal(t, uint8(2), p.PayloadType)
 			require.Equal(t, binary.BigEndian.Uint16(p.Payload), seqNum)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 	}
 
 	select {
 	case p := <-stream.WrittenRTP():
-		t.Errorf("no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
+		assert.Fail(t, "no more rtp packets expected, found sequence number: %v", p.SequenceNumber)
 	case <-time.After(10 * time.Millisecond):
 	}
 }
@@ -355,7 +356,7 @@ func TestResponderInterceptor_BypassUnknownSSRCs(t *testing.T) {
 			require.Equal(t, seqNum, p.SequenceNumber)
 			require.Equal(t, uint32(1), p.SSRC)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 
 		select {
@@ -363,7 +364,7 @@ func TestResponderInterceptor_BypassUnknownSSRCs(t *testing.T) {
 			require.Equal(t, seqNum, p.SequenceNumber)
 			require.Equal(t, uint32(2), p.SSRC)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 	}
 
@@ -373,7 +374,7 @@ func TestResponderInterceptor_BypassUnknownSSRCs(t *testing.T) {
 	case p := <-stream.WrittenRTP():
 		require.Equal(t, uint16(13), p.SequenceNumber)
 	case <-time.After(10 * time.Millisecond):
-		t.Fatal("written rtp packet not found")
+		assert.Fail(t, "written rtp packet not found")
 	}
 
 	stream.ReceiveRTCP([]rtcp.Packet{
@@ -393,7 +394,7 @@ func TestResponderInterceptor_BypassUnknownSSRCs(t *testing.T) {
 			require.Equal(t, uint32(1), p.SSRC)
 			require.Equal(t, seqNum, p.SequenceNumber)
 		case <-time.After(10 * time.Millisecond):
-			t.Fatal("written rtp packet not found")
+			assert.Fail(t, "written rtp packet not found")
 		}
 	}
 }

--- a/pkg/rfc8888/interceptor_test.go
+++ b/pkg/rfc8888/interceptor_test.go
@@ -124,7 +124,7 @@ func TestInterceptor(t *testing.T) {
 			case r := <-stream.ReadRTP():
 				assert.NoError(t, r.Err)
 			case <-time.After(10 * time.Millisecond):
-				t.Fatal("receiver rtp packet not found")
+				assert.Fail(t, "receiver rtp packet not found")
 			}
 		}
 		mTick.Tick(zero.Add(time.Second))
@@ -209,7 +209,7 @@ func TestInterceptor(t *testing.T) {
 			case r := <-stream.ReadRTP():
 				assert.NoError(t, r.Err)
 			case <-time.After(10 * time.Millisecond):
-				t.Fatal("receiver rtp packet not found")
+				assert.Fail(t, "receiver rtp packet not found")
 			}
 		}
 		mTick.Tick(zero.Add(time.Second))

--- a/pkg/stats/stats_recorder_test.go
+++ b/pkg/stats/stats_recorder_test.go
@@ -864,9 +864,7 @@ func TestGetStatsNotBlocking(t *testing.T) {
 
 	<-ctx.Done()
 
-	if err := ctx.Err(); err != nil && errors.Is(err, context.DeadlineExceeded) {
-		t.Error("it shouldn't block")
-	}
+	assert.False(t, errors.Is(ctx.Err(), context.DeadlineExceeded), "it shouldn't block")
 }
 
 func TestQueueNotBlocking(t *testing.T) {
@@ -914,9 +912,7 @@ func TestQueueNotBlocking(t *testing.T) {
 
 			<-ctx.Done()
 
-			if err := ctx.Err(); err != nil && errors.Is(err, context.DeadlineExceeded) {
-				t.Error("it shouldn't block")
-			}
+			assert.False(t, errors.Is(ctx.Err(), context.DeadlineExceeded), "it shouldn't block")
 		})
 	}
 }

--- a/pkg/twcc/header_extension_interceptor_test.go
+++ b/pkg/twcc/header_extension_interceptor_test.go
@@ -69,7 +69,7 @@ func TestHeaderExtensionInterceptor(t *testing.T) {
 							assert.Equal(t, seqNum, p.SequenceNumber)
 							ch <- p
 						case <-time.After(10 * time.Millisecond):
-							panic("written rtp packet not found")
+							assert.FailNow(t, "written rtp packet not found")
 						}
 					}
 				}(pChan, uint16(i+1)) //nolint:gosec // G115

--- a/pkg/twcc/twcc_test.go
+++ b/pkg/twcc/twcc_test.go
@@ -17,9 +17,8 @@ func rtcpToTwcc(t *testing.T, in []rtcp.Packet) []*rtcp.TransportLayerCC {
 	out := make([]*rtcp.TransportLayerCC, len(in))
 	var ok bool
 	for i, pkt := range in {
-		if out[i], ok = pkt.(*rtcp.TransportLayerCC); !ok {
-			t.Fatal("Failed to cast")
-		}
+		out[i], ok = pkt.(*rtcp.TransportLayerCC)
+		assert.True(t, ok, "Expected TransportLayerCC, got %T", pkt)
 	}
 
 	return out


### PR DESCRIPTION
Description
Use testify's assert package instead of the standard library's testing package.

Reference issue
https://github.com/pion/.goassets/pull/222