### PR TITLE
Improve memory efficiency

### DIFF
--- a/pkg/nack/generator_interceptor_test.go
+++ b/pkg/nack/generator_interceptor_test.go
@@ -20,6 +20,7 @@ func TestGeneratorInterceptor(t *testing.T) {
 	f, err := NewGeneratorInterceptor(
 		GeneratorSize(64),
 		GeneratorSkipLastN(2),
+		GeneratorMaxNacksPerPacket(10),
 		GeneratorInterval(interval),
 		GeneratorLog(logging.NewDefaultLoggerFactory().NewLogger("test")),
 	)

--- a/pkg/nack/receive_log.go
+++ b/pkg/nack/receive_log.go
@@ -97,7 +97,7 @@ func (s *receiveLog) get(seq uint16) bool {
 	return s.getReceived(seq)
 }
 
-func (s *receiveLog) missingSeqNumbers(skipLastN uint16) []uint16 {
+func (s *receiveLog) missingSeqNumbers(skipLastN uint16, missingPacketSeqNums []uint16) []uint16 {
 	s.m.RLock()
 	defer s.m.RUnlock()
 
@@ -107,14 +107,15 @@ func (s *receiveLog) missingSeqNumbers(skipLastN uint16) []uint16 {
 		return nil
 	}
 
-	missingPacketSeqNums := make([]uint16, 0)
+	c := 0
 	for i := s.lastConsecutive + 1; i != until+1; i++ {
 		if !s.getReceived(i) {
-			missingPacketSeqNums = append(missingPacketSeqNums, i)
+			missingPacketSeqNums[c] = i
+			c++
 		}
 	}
 
-	return missingPacketSeqNums
+	return missingPacketSeqNums[:c]
 }
 
 func (s *receiveLog) setReceived(seq uint16) {


### PR DESCRIPTION
Refactored packet processing to avoid multiple make calls and eliminate the use of append. This reduces garbage collection overhead and improves overall memory management efficiency.

#### Description

#### Reference issue
Fixes #...
