### PR TITLE
FEC interceptor enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   Pion Interceptor
   <br>
 </h1>
-<h4 align="center">RTCP and RTCP processors for building real time communications</h4>
+<h4 align="center">RTP and RTCP processors for building real time communications</h4>
 <p align="center">
   <a href="https://pion.ly"><img src="https://img.shields.io/badge/pion-interceptor-gray.svg?longCache=true&colorB=brightgreen" alt="Pion Interceptor"></a>
   <a href="https://discord.gg/PngbdqpFbt"><img src="https://img.shields.io/badge/join-us%20on%20discord-gray.svg?longCache=true&logo=discord&colorB=brightblue" alt="join us on Discord"></a> <a href="https://bsky.app/profile/pion.ly"><img src="https://img.shields.io/badge/follow-us%20on%20bluesky-gray.svg?longCache=true&logo=bluesky&colorB=brightblue" alt="Follow us on Bluesky"></a>
@@ -36,12 +36,12 @@ by anyone. With the following tenets in mind.
 * [Google Congestion Control](https://github.com/pion/interceptor/tree/master/pkg/gcc)
 * [Stats](https://github.com/pion/interceptor/tree/master/pkg/stats) A [webrtc-stats](https://www.w3.org/TR/webrtc-stats/) compliant statistics generation
 * [Interval PLI](https://github.com/pion/interceptor/tree/master/pkg/intervalpli) Generate PLI on a interval. Useful when no decoder is available.
+* [FlexFec](https://github.com/pion/interceptor/tree/master/pkg/flexfec) – [FlexFEC-03](https://datatracker.ietf.org/doc/html/draft-ietf-payload-flexible-fec-scheme-03) encoder implementation
 
 ### Planned Interceptors
 * Bandwidth Estimation
   - [NADA](https://tools.ietf.org/html/rfc8698)
 * JitterBuffer, re-order packets and wait for arrival
-* [FlexFec](https://tools.ietf.org/html/draft-ietf-payload-flexible-fec-scheme-20)
 * [RTCP Feedback for Congestion Control](https://datatracker.ietf.org/doc/html/rfc8888) the standardized alternative to TWCC.
 
 ### Interceptor Public API

--- a/pkg/flexfec/encoder_interceptor.go
+++ b/pkg/flexfec/encoder_interceptor.go
@@ -4,20 +4,29 @@
 package flexfec
 
 import (
+	"errors"
+	"sync"
+
 	"github.com/pion/interceptor"
 	"github.com/pion/rtp"
 )
 
+// streamState holds the state for a single stream.
+type streamState struct {
+	mu             sync.Mutex
+	flexFecEncoder FlexEncoder
+	packetBuffer   []rtp.Packet
+}
+
 // FecInterceptor implements FlexFec.
 type FecInterceptor struct {
 	interceptor.NoOp
-	flexFecEncoder     FlexEncoder
-	packetBuffer       []rtp.Packet
-	minNumMediaPackets uint32
+	mu              sync.Mutex
+	streams         map[uint32]*streamState
+	numMediaPackets uint32
+	numFecPackets   uint32
+	encoderFactory  EncoderFactory
 }
-
-// FecOption can be used to set initial options on Fec encoder interceptors.
-type FecOption func(d *FecInterceptor) error
 
 // FecInterceptorFactory creates new FecInterceptors.
 type FecInterceptorFactory struct {
@@ -31,16 +40,28 @@ func NewFecInterceptor(opts ...FecOption) (*FecInterceptorFactory, error) {
 
 // NewInterceptor constructs a new FecInterceptor.
 func (r *FecInterceptorFactory) NewInterceptor(_ string) (interceptor.Interceptor, error) {
-	// Hardcoded for now:
-	// Min num media packets to encode FEC -> 5
-	// Min num fec packets -> 1
-
 	interceptor := &FecInterceptor{
-		packetBuffer:       make([]rtp.Packet, 0),
-		minNumMediaPackets: 5,
+		streams:         make(map[uint32]*streamState),
+		numMediaPackets: 5,
+		numFecPackets:   2,
+		encoderFactory:  FlexEncoder03Factory{},
+	}
+
+	for _, opt := range r.opts {
+		if err := opt(interceptor); err != nil {
+			return nil, err
+		}
 	}
 
 	return interceptor, nil
+}
+
+// UnbindLocalStream removes the stream state for a specific SSRC.
+func (r *FecInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.streams, info.SSRC)
 }
 
 // BindLocalStream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
@@ -48,37 +69,60 @@ func (r *FecInterceptorFactory) NewInterceptor(_ string) (interceptor.Intercepto
 func (r *FecInterceptor) BindLocalStream(
 	info *interceptor.StreamInfo, writer interceptor.RTPWriter,
 ) interceptor.RTPWriter {
-	// Chromium supports version flexfec-03 of existing draft, this is the one we will configure by default
-	// although we should support configuring the latest (flexfec-20) as well.
-	r.flexFecEncoder = NewFlexEncoder03(info.PayloadType, info.SSRC)
+	if info.PayloadTypeForwardErrorCorrection == 0 || info.SSRCForwardErrorCorrection == 0 {
+		return writer
+	}
+
+	mediaSSRC := info.SSRC
+
+	r.mu.Lock()
+	stream := &streamState{
+		// Chromium supports version flexfec-03 of existing draft, this is the one we will configure by default
+		// although we should support configuring the latest (flexfec-20) as well.
+		flexFecEncoder: r.encoderFactory.NewEncoder(info.PayloadTypeForwardErrorCorrection, info.SSRCForwardErrorCorrection),
+		packetBuffer:   make([]rtp.Packet, 0),
+	}
+	r.streams[mediaSSRC] = stream
+	r.mu.Unlock()
 
 	return interceptor.RTPWriterFunc(
 		func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
-			r.packetBuffer = append(r.packetBuffer, rtp.Packet{
+			// Ignore non-media packets
+			if header.SSRC != mediaSSRC {
+				return writer.Write(header, payload, attributes)
+			}
+
+			var fecPackets []rtp.Packet
+			stream.mu.Lock()
+			stream.packetBuffer = append(stream.packetBuffer, rtp.Packet{
 				Header:  *header,
 				Payload: payload,
 			})
 
-			// Send the media RTP packet
-			result, err := writer.Write(header, payload, attributes)
-
-			// Send the FEC packets
-			var fecPackets []rtp.Packet
-			if len(r.packetBuffer) == int(r.minNumMediaPackets) {
-				fecPackets = r.flexFecEncoder.EncodeFec(r.packetBuffer, 2)
-
-				for i := range fecPackets {
-					fecResult, fecErr := writer.Write(&(fecPackets[i].Header), fecPackets[i].Payload, attributes)
-
-					if fecErr != nil && fecResult == 0 {
-						break
-					}
-				}
+			// Check if we have enough packets to generate FEC
+			if len(stream.packetBuffer) == int(r.numMediaPackets) {
+				fecPackets = stream.flexFecEncoder.EncodeFec(stream.packetBuffer, r.numFecPackets)
 				// Reset the packet buffer now that we've sent the corresponding FEC packets.
-				r.packetBuffer = nil
+				stream.packetBuffer = nil
+			}
+			stream.mu.Unlock()
+
+			var errs []error
+			result, err := writer.Write(header, payload, attributes)
+			if err != nil {
+				errs = append(errs, err)
 			}
 
-			return result, err
+			for _, packet := range fecPackets {
+				header := packet.Header
+
+				_, err = writer.Write(&header, packet.Payload, attributes)
+				if err != nil {
+					errs = append(errs, err)
+				}
+			}
+
+			return result, errors.Join(errs...)
 		},
 	)
 }

--- a/pkg/flexfec/encoder_interceptor_test.go
+++ b/pkg/flexfec/encoder_interceptor_test.go
@@ -1,0 +1,391 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flexfec_test
+
+import (
+	"testing"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/test"
+	"github.com/pion/interceptor/pkg/flexfec"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockFlexEncoder struct {
+	Called        bool
+	MediaPackets  []rtp.Packet
+	NumFECPackets uint32
+	FECPackets    []rtp.Packet
+}
+
+func NewMockFlexEncoder(fecPackets []rtp.Packet) *MockFlexEncoder {
+	return &MockFlexEncoder{
+		Called:     false,
+		FECPackets: fecPackets,
+	}
+}
+
+func (m *MockFlexEncoder) EncodeFec(mediaPackets []rtp.Packet, numFecPackets uint32) []rtp.Packet {
+	m.Called = true
+	m.MediaPackets = mediaPackets
+	m.NumFECPackets = numFecPackets
+
+	return m.FECPackets
+}
+
+type MockEncoderFactory struct {
+	Called      bool
+	PayloadType uint8
+	SSRC        uint32
+	Encoder     flexfec.FlexEncoder
+}
+
+func NewMockEncoderFactory(encoder flexfec.FlexEncoder) *MockEncoderFactory {
+	return &MockEncoderFactory{
+		Called:  false,
+		Encoder: encoder,
+	}
+}
+
+func (m *MockEncoderFactory) NewEncoder(payloadType uint8, ssrc uint32) flexfec.FlexEncoder {
+	m.Called = true
+	m.PayloadType = payloadType
+	m.SSRC = ssrc
+
+	return m.Encoder
+}
+
+func TestFecInterceptor_GenerateAndWriteFecPackets(t *testing.T) {
+	fecPackets := []rtp.Packet{
+		{
+			Header: rtp.Header{
+				SSRC:           2000,
+				PayloadType:    100,
+				SequenceNumber: 1000,
+			},
+			Payload: []byte{0xFE, 0xC0, 0xDE},
+		},
+	}
+	mockEncoder := NewMockFlexEncoder(fecPackets)
+	mockFactory := NewMockEncoderFactory(mockEncoder)
+
+	factory, err := flexfec.NewFecInterceptor(
+		flexfec.FECEncoderFactory(mockFactory),
+		flexfec.NumMediaPackets(2),
+		flexfec.NumFECPackets(1),
+	)
+	assert.NoError(t, err)
+
+	i, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	info := &interceptor.StreamInfo{
+		SSRC:                              1000,
+		PayloadTypeForwardErrorCorrection: 100,
+		SSRCForwardErrorCorrection:        2000,
+	}
+
+	stream := test.NewMockStream(info, i)
+	defer assert.NoError(t, stream.Close())
+
+	assert.True(t, mockFactory.Called, "NewEncoder should have been called")
+	assert.Equal(t, uint8(100), mockFactory.PayloadType, "Should be called with correct payload type")
+	assert.Equal(t, uint32(2000), mockFactory.SSRC, "Should be called with correct SSRC")
+
+	for i := uint16(1); i <= 2; i++ {
+		packet := &rtp.Packet{
+			Header: rtp.Header{
+				SSRC:           1000,
+				SequenceNumber: i,
+				PayloadType:    96,
+			},
+			Payload: []byte{0x01, 0x02, 0x03, 0x04},
+		}
+		err = stream.WriteRTP(packet)
+		assert.NoError(t, err)
+	}
+
+	var mediaPacketsCount, fecPacketsCount int
+	for i := 0; i < 3; i++ {
+		select {
+		case packet := <-stream.WrittenRTP():
+			switch packet.PayloadType {
+			case 96:
+				mediaPacketsCount++
+			case 100:
+				fecPacketsCount++
+				assert.Equal(t, uint32(2000), packet.SSRC)
+				assert.Equal(t, []byte{0xFE, 0xC0, 0xDE}, packet.Payload)
+			}
+		default:
+			assert.Fail(t, "Not enough packets were written")
+		}
+	}
+
+	assert.Equal(t, 2, mediaPacketsCount, "Should have written 2 media packets")
+	assert.Equal(t, 1, fecPacketsCount, "Should have written 1 FEC packet")
+	assert.True(t, mockEncoder.Called, "EncodeFec should have been called")
+	assert.Equal(t, uint32(1), mockEncoder.NumFECPackets, "Should be called with correct number of FEC packets")
+}
+
+func TestFecInterceptor_BypassStreamWhenFecPtAndSsrcAreZero(t *testing.T) {
+	fecPackets := []rtp.Packet{
+		{
+			Header: rtp.Header{
+				SSRC:           2000,
+				PayloadType:    100,
+				SequenceNumber: 1000,
+			},
+			Payload: []byte{0xFE, 0xC0, 0xDE},
+		},
+	}
+	mockEncoder := NewMockFlexEncoder(fecPackets)
+	mockFactory := NewMockEncoderFactory(mockEncoder)
+
+	factory, err := flexfec.NewFecInterceptor(
+		flexfec.FECEncoderFactory(mockFactory),
+		flexfec.NumMediaPackets(1),
+		flexfec.NumFECPackets(1),
+	)
+	assert.NoError(t, err)
+
+	i, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	info := &interceptor.StreamInfo{
+		SSRC:                              1,
+		PayloadTypeForwardErrorCorrection: 0,
+		SSRCForwardErrorCorrection:        0,
+	}
+
+	stream := test.NewMockStream(info, i)
+	defer assert.NoError(t, stream.Close())
+
+	packet := &rtp.Packet{
+		Header: rtp.Header{
+			SSRC:        1,
+			PayloadType: 96,
+		},
+		Payload: []byte{0x01, 0x02, 0x03, 0x04},
+	}
+
+	err = stream.WriteRTP(packet)
+	assert.NoError(t, err)
+
+	select {
+	case writtenPacket := <-stream.WrittenRTP():
+		assert.Equal(t, packet.SSRC, writtenPacket.SSRC)
+		assert.Equal(t, packet.SequenceNumber, writtenPacket.SequenceNumber)
+		assert.Equal(t, packet.Payload, writtenPacket.Payload)
+	default:
+		assert.Fail(t, "No packet was written")
+	}
+
+	select {
+	case <-stream.WrittenRTP():
+		assert.Fail(t, "Only one packet must be received")
+	default:
+	}
+
+	assert.False(t, mockEncoder.Called, "EncodeFec should not have been called")
+}
+
+func TestFecInterceptor_EncodeOnlyPacketsWithMediaSsrc(t *testing.T) {
+	mockEncoder := NewMockFlexEncoder(nil)
+	mockFactory := NewMockEncoderFactory(mockEncoder)
+
+	factory, err := flexfec.NewFecInterceptor(
+		flexfec.FECEncoderFactory(mockFactory),
+		flexfec.NumMediaPackets(2),
+		flexfec.NumFECPackets(1),
+	)
+	assert.NoError(t, err)
+
+	i, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	info := &interceptor.StreamInfo{
+		SSRC:                              1000,
+		PayloadTypeForwardErrorCorrection: 100,
+		SSRCForwardErrorCorrection:        2000,
+	}
+
+	stream := test.NewMockStream(info, i)
+	defer assert.NoError(t, stream.Close())
+
+	mediaPacket := &rtp.Packet{
+		Header: rtp.Header{
+			SSRC:           1000,
+			SequenceNumber: 1,
+			PayloadType:    96,
+		},
+		Payload: []byte{0x01, 0x02, 0x03, 0x04},
+	}
+
+	nonMediaPacket := &rtp.Packet{
+		Header: rtp.Header{
+			SSRC:           3000, // Different from mediaSSRC
+			SequenceNumber: 2,
+			PayloadType:    96,
+		},
+		Payload: []byte{0x05, 0x06, 0x07, 0x08},
+	}
+
+	err = stream.WriteRTP(mediaPacket)
+	assert.NoError(t, err)
+
+	err = stream.WriteRTP(nonMediaPacket)
+	assert.NoError(t, err)
+
+	// The non-media packet should be passed through without being added to the buffer
+	select {
+	case writtenPacket := <-stream.WrittenRTP():
+		assert.Equal(t, mediaPacket.SSRC, writtenPacket.SSRC)
+	default:
+		assert.Fail(t, "No media packet was written")
+	}
+
+	select {
+	case writtenPacket := <-stream.WrittenRTP():
+		assert.Equal(t, nonMediaPacket.SSRC, writtenPacket.SSRC)
+	default:
+		assert.Fail(t, "No non-media packet was written")
+	}
+
+	assert.False(t, mockEncoder.Called, "EncodeFec should not have been called")
+}
+
+type EncoderFactoryFunc func(payloadType uint8, ssrc uint32) flexfec.FlexEncoder
+
+func (f EncoderFactoryFunc) NewEncoder(payloadType uint8, ssrc uint32) flexfec.FlexEncoder {
+	return f(payloadType, ssrc)
+}
+
+// nolint:cyclop
+func TestFecInterceptor_HandleMultipleStreamsCorrectly(t *testing.T) {
+	fecPackets1 := []rtp.Packet{
+		{
+			Header: rtp.Header{
+				SSRC:           2000,
+				PayloadType:    100,
+				SequenceNumber: 1000,
+			},
+			Payload: []byte{0xFE, 0xC0, 0xDE},
+		},
+	}
+	mockEncoder1 := NewMockFlexEncoder(fecPackets1)
+
+	fecPackets2 := []rtp.Packet{
+		{
+			Header: rtp.Header{
+				SSRC:           3000,
+				PayloadType:    101,
+				SequenceNumber: 1000,
+			},
+			Payload: []byte{0xFE, 0xC0, 0xDE},
+		},
+	}
+	mockEncoder2 := NewMockFlexEncoder(fecPackets2)
+
+	customFactory := EncoderFactoryFunc(func(payloadType uint8, ssrc uint32) flexfec.FlexEncoder {
+		if payloadType == 100 && ssrc == 2000 {
+			return mockEncoder1
+		} else if payloadType == 101 && ssrc == 3000 {
+			return mockEncoder2
+		}
+
+		return nil
+	})
+
+	factory, err := flexfec.NewFecInterceptor(
+		flexfec.FECEncoderFactory(customFactory),
+		flexfec.NumMediaPackets(2),
+	)
+	assert.NoError(t, err)
+
+	fecInterceptor, err := factory.NewInterceptor("")
+	assert.NoError(t, err)
+
+	info1 := &interceptor.StreamInfo{
+		SSRC:                              1000,
+		PayloadTypeForwardErrorCorrection: 100,
+		SSRCForwardErrorCorrection:        2000,
+	}
+
+	info2 := &interceptor.StreamInfo{
+		SSRC:                              1001,
+		PayloadTypeForwardErrorCorrection: 101,
+		SSRCForwardErrorCorrection:        3000,
+	}
+
+	stream1 := test.NewMockStream(info1, fecInterceptor)
+	defer assert.NoError(t, stream1.Close())
+
+	stream2 := test.NewMockStream(info2, fecInterceptor)
+	defer assert.NoError(t, stream2.Close())
+
+	for idx := uint16(1); idx <= 2; idx++ {
+		packet1 := &rtp.Packet{
+			Header: rtp.Header{
+				SSRC:           1000,
+				SequenceNumber: idx,
+				PayloadType:    96,
+			},
+			Payload: []byte{0x01, 0x02, 0x03, 0x04},
+		}
+		err = stream1.WriteRTP(packet1)
+		assert.NoError(t, err)
+
+		packet2 := &rtp.Packet{
+			Header: rtp.Header{
+				SSRC:           1001,
+				SequenceNumber: idx,
+				PayloadType:    97,
+			},
+			Payload: []byte{0x05, 0x06, 0x07, 0x08},
+		}
+		err = stream2.WriteRTP(packet2)
+		assert.NoError(t, err)
+	}
+
+	assert.True(t, mockEncoder1.Called, "First encoder's EncodeFec should have been called")
+	assert.True(t, mockEncoder2.Called, "Second encoder's EncodeFec should have been called")
+
+	mediaPacketsCount1 := 0
+	fecPacketsCount1 := 0
+	for i := 0; i < 3; i++ {
+		select {
+		case packet := <-stream1.WrittenRTP():
+			switch packet.SSRC {
+			case 1000:
+				mediaPacketsCount1++
+			case 2000:
+				fecPacketsCount1++
+			}
+		default:
+			assert.Fail(t, "No packet from stream1")
+		}
+	}
+	assert.Equal(t, 2, mediaPacketsCount1, "Expected 2 media packets for stream1")
+	assert.Equal(t, 1, fecPacketsCount1, "Expected 1 FEC packet for stream1")
+
+	mediaPacketsCount2 := 0
+	fecPacketsCount2 := 0
+	for i := 0; i < 3; i++ {
+		select {
+		case packet := <-stream2.WrittenRTP():
+			switch packet.SSRC {
+			case 1001:
+				mediaPacketsCount2++
+			case 3000:
+				fecPacketsCount2++
+			}
+		default:
+			assert.Fail(t, "No packet from stream2")
+		}
+	}
+	assert.Equal(t, 2, mediaPacketsCount2, "Expected 2 media packets for stream2")
+	assert.Equal(t, 1, fecPacketsCount2, "Expected 1 FEC packet for stream2")
+}

--- a/pkg/flexfec/flexfec_03_test.go
+++ b/pkg/flexfec/flexfec_03_test.go
@@ -72,7 +72,7 @@ func generatePackets(t *testing.T, seqs []uint16) ([]rtp.Packet, []rtp.Packet) {
 		mediaPackets = append(mediaPackets, packet)
 	}
 
-	encoder := NewFlexEncoder03(payloadType, ssrc)
+	encoder := FlexEncoder03Factory{}.NewEncoder(payloadType, ssrc)
 	fecPackets := encoder.EncodeFec(mediaPackets, 2)
 
 	return mediaPackets, fecPackets

--- a/pkg/flexfec/flexfec_encoder.go
+++ b/pkg/flexfec/flexfec_encoder.go
@@ -20,12 +20,17 @@ const (
 	BaseFecHeaderSize = 12
 )
 
+// EncoderFactory is an interface for generic FEC encoders.
+type EncoderFactory interface {
+	NewEncoder(payloadType uint8, ssrc uint32) FlexEncoder
+}
+
 // FlexEncoder is the interface that FecInterceptor uses to encode Fec packets.
 type FlexEncoder interface {
 	EncodeFec(mediaPackets []rtp.Packet, numFecPackets uint32) []rtp.Packet
 }
 
-// FlexEncoder20 implements the Fec encoding mechanism for the "Flex" variant of FlexFec.
+// FlexEncoder20 implementation is WIP, contains bugs and no tests. Check out FlexEncoder03.
 type FlexEncoder20 struct {
 	fecBaseSn   uint16
 	payloadType uint8
@@ -33,7 +38,8 @@ type FlexEncoder20 struct {
 	coverage    *ProtectionCoverage
 }
 
-// NewFlexEncoder returns a new FlexFecEncer.
+// NewFlexEncoder returns a new FlexEncoder20.
+// FlexEncoder20 implementation is WIP, contains bugs and no tests. Check out FlexEncoder03.
 func NewFlexEncoder(payloadType uint8, ssrc uint32) *FlexEncoder20 {
 	return &FlexEncoder20{
 		payloadType: payloadType,

--- a/pkg/flexfec/flexfec_encoder_03.go
+++ b/pkg/flexfec/flexfec_encoder_03.go
@@ -26,7 +26,15 @@ type FlexEncoder03 struct {
 	coverage    *ProtectionCoverage
 }
 
-// NewFlexEncoder03 returns a new FlexFecEncoder.
+// FlexEncoder03Factory is a factory for FlexFEC-03 encoders.
+type FlexEncoder03Factory struct{}
+
+// NewEncoder creates new FlexFEC-03 encoder.
+func (f FlexEncoder03Factory) NewEncoder(payloadType uint8, ssrc uint32) FlexEncoder {
+	return NewFlexEncoder03(payloadType, ssrc)
+}
+
+// NewFlexEncoder03 creates new FlexFEC-03 encoder.
 func NewFlexEncoder03(payloadType uint8, ssrc uint32) *FlexEncoder03 {
 	return &FlexEncoder03{
 		payloadType: payloadType,

--- a/pkg/flexfec/flexfec_encoder_03_test.go
+++ b/pkg/flexfec/flexfec_encoder_03_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFlexEncoder03_EncodeFec_EmptyMediaPackets(t *testing.T) {
-	encoder := NewFlexEncoder03(96, 1234)
+	encoder := FlexEncoder03Factory{}.NewEncoder(96, 1234)
 	var mediaPackets []rtp.Packet
 
 	result := encoder.EncodeFec(mediaPackets, 1)
@@ -20,7 +20,7 @@ func TestFlexEncoder03_EncodeFec_EmptyMediaPackets(t *testing.T) {
 }
 
 func TestFlexEncoder03_EncodeFec_OutOfOrderPackets(t *testing.T) {
-	encoder := NewFlexEncoder03(96, 1234)
+	encoder := FlexEncoder03Factory{}.NewEncoder(96, 1234)
 	mediaPackets := []rtp.Packet{
 		{
 			Header: rtp.Header{
@@ -42,7 +42,7 @@ func TestFlexEncoder03_EncodeFec_OutOfOrderPackets(t *testing.T) {
 }
 
 func TestFlexEncoder03_EncodeFec_MissingPackets(t *testing.T) {
-	encoder := NewFlexEncoder03(96, 1234)
+	encoder := FlexEncoder03Factory{}.NewEncoder(96, 1234)
 	mediaPackets := []rtp.Packet{
 		{
 			Header: rtp.Header{
@@ -63,7 +63,7 @@ func TestFlexEncoder03_EncodeFec_MissingPackets(t *testing.T) {
 }
 
 func TestFlexEncoder03_EncodeFec_DifferentPayloadSizes(t *testing.T) {
-	encoder := NewFlexEncoder03(96, 1234)
+	encoder := FlexEncoder03Factory{}.NewEncoder(96, 1234)
 
 	smallPayload := []byte{1, 2, 3}
 	largePayload := []byte{1, 2, 3, 4, 5, 6, 7, 8}

--- a/pkg/flexfec/option.go
+++ b/pkg/flexfec/option.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flexfec
+
+// FecOption can be used to set initial options on Fec encoder interceptors.
+type FecOption func(d *FecInterceptor) error
+
+// NumMediaPackets sets the number of media packets to accumulate before generating another FEC packets batch.
+func NumMediaPackets(numMediaPackets uint32) FecOption {
+	return func(f *FecInterceptor) error {
+		f.numMediaPackets = numMediaPackets
+
+		return nil
+	}
+}
+
+// NumFECPackets sets the number of FEC packets to generate for each batch of media packets.
+func NumFECPackets(numFecPackets uint32) FecOption {
+	return func(f *FecInterceptor) error {
+		f.numFecPackets = numFecPackets
+
+		return nil
+	}
+}
+
+// FECEncoderFactory sets the custom factory for constructing the FEC Encoders.
+func FECEncoderFactory(factory EncoderFactory) FecOption {
+	return func(f *FecInterceptor) error {
+		f.encoderFactory = factory
+
+		return nil
+	}
+}


### PR DESCRIPTION
#### Description

1. Pass in correct payload type and ssrc (don't use the video track's payload type and ssrc
2. Store only main ssrc packets in buffer
3. Allow custom FEC encoders
4. Add options for NumMediaPackets and NumFECPackets
5. Allow multiple RTP streams with FEC support
6. Encode FEC only if negotiated 

#### Reference issue
Fixes https://github.com/pion/interceptor/issues/332

