### PR TITLE
Optimize FlexFEC-03 encoder

### DIFF
--- a/pkg/flexfec/flexfec_benchmark_test.go
+++ b/pkg/flexfec/flexfec_benchmark_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flexfec_test
+
+import (
+	"testing"
+
+	"github.com/pion/interceptor/pkg/flexfec"
+	"github.com/pion/rtp"
+)
+
+const (
+	payloadType         = uint8(49)
+	ssrc                = uint32(867589674)
+	protectedStreamSSRC = uint32(476325762)
+)
+
+// generateMediaPackets creates a slice of RTP packets with fixed-size payloads.
+func generateMediaPackets(n int, startSeq uint16) []rtp.Packet {
+	mediaPackets := make([]rtp.Packet, 0, n)
+	for i := 0; i < n; i++ {
+		payload := []byte{
+			// Payload with some random data
+			1, 2, 3, 4, 5, byte(i),
+		}
+		packet := rtp.Packet{
+			Header: rtp.Header{
+				Marker:         true,
+				Extension:      false,
+				Version:        2,
+				PayloadType:    96,
+				SequenceNumber: startSeq + uint16(i), //nolint:gosec // G115
+				Timestamp:      3653407706,
+				SSRC:           protectedStreamSSRC,
+				CSRC:           []uint32{},
+			},
+			Payload: payload,
+		}
+
+		mediaPackets = append(mediaPackets, packet)
+	}
+
+	return mediaPackets
+}
+
+// generateMediaPacketsWithSizes creates a slice of RTP packets with varying payload sizes.
+func generateMediaPacketsWithSizes(n int, startSeq uint16, minSize, maxSize int) []rtp.Packet {
+	mediaPackets := make([]rtp.Packet, 0, n)
+
+	for i := 0; i < n; i++ {
+		// Calculate a size that varies between minSize and maxSize based on the packet index
+		size := minSize + (i % (maxSize - minSize + 1))
+
+		// Create a payload of the calculated size
+		payload := make([]byte, size)
+		// Fill with some pattern data
+		for j := 0; j < size; j++ {
+			payload[j] = byte((j + i) % 256)
+		}
+
+		packet := rtp.Packet{
+			Header: rtp.Header{
+				Marker:         true,
+				Extension:      false,
+				Version:        2,
+				PayloadType:    96,
+				SequenceNumber: startSeq + uint16(i), //nolint:gosec // G115
+				Timestamp:      3653407706,
+				SSRC:           protectedStreamSSRC,
+				CSRC:           []uint32{},
+			},
+			Payload: payload,
+		}
+
+		mediaPackets = append(mediaPackets, packet)
+	}
+
+	return mediaPackets
+}
+
+// BenchmarkFlexEncoder03_EncodeFec benchmarks the FEC encoding with fixed configurations.
+func BenchmarkFlexEncoder03_EncodeFec(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		mediaPackets  int
+		fecPackets    uint32
+		sequenceStart uint16
+	}{
+		{"Small_2FEC", 5, 2, 1000},
+		{"Medium_3FEC", 10, 3, 1000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			mediaPackets := generateMediaPackets(bm.mediaPackets, bm.sequenceStart)
+			encoder := flexfec.NewFlexEncoder03(payloadType, ssrc)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = encoder.EncodeFec(mediaPackets, bm.fecPackets)
+			}
+		})
+	}
+}
+
+// BenchmarkFlexEncoder03_EncodeFecVaryingSizes benchmarks the FEC encoding with varying packet sizes.
+func BenchmarkFlexEncoder03_EncodeFecVaryingSizes(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		mediaPackets  int
+		fecPackets    uint32
+		minSize       int
+		maxSize       int
+		sequenceStart uint16
+	}{
+		{"ManySmall_2FEC", 20, 2, 50, 150, 1000},
+		{"ManyMedium_3FEC", 30, 3, 200, 800, 1000},
+		{"ManyLarge_2FEC", 40, 2, 900, 1400, 1000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			mediaPackets := generateMediaPacketsWithSizes(bm.mediaPackets, bm.sequenceStart, bm.minSize, bm.maxSize)
+			encoder := flexfec.NewFlexEncoder03(payloadType, ssrc)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = encoder.EncodeFec(mediaPackets, bm.fecPackets)
+			}
+		})
+	}
+}

--- a/pkg/flexfec/flexfec_encoder_03.go
+++ b/pkg/flexfec/flexfec_encoder_03.go
@@ -7,8 +7,8 @@ package flexfec
 
 import (
 	"encoding/binary"
+	"sync"
 
-	"github.com/pion/interceptor/pkg/flexfec/util"
 	"github.com/pion/rtp"
 )
 
@@ -16,7 +16,18 @@ const (
 	// BaseFec03HeaderSize represents the minium FEC payload's header size including the
 	// required first mask.
 	BaseFec03HeaderSize = 20
+	// maxRTPPacketSize represents the maximum size of an RTP packet buffer.
+	// This is a reasonable upper bound for typical RTP packets.
+	maxRTPPacketSize = 1500
 )
+
+var bufferPool = sync.Pool{ //nolint:gochecknoglobals
+	New: func() any {
+		b := make([]byte, maxRTPPacketSize)
+
+		return &b
+	},
+}
 
 // FlexEncoder03 implements the Fec encoding mechanism for the "Flex" variant of FlexFec.
 type FlexEncoder03 struct {
@@ -71,52 +82,26 @@ func (flex *FlexEncoder03) EncodeFec(mediaPackets []rtp.Packet, numFecPackets ui
 	}
 
 	// Generate FEC payloads
-	fecPackets := make([]rtp.Packet, numFecPackets)
+	fecPackets := make([]rtp.Packet, 0, numFecPackets)
 	for fecPacketIndex := uint32(0); fecPacketIndex < numFecPackets; fecPacketIndex++ {
-		fecPackets[fecPacketIndex] = flex.encodeFlexFecPacket(fecPacketIndex, mediaPackets[0].SequenceNumber)
+		fecPacket, ok := flex.encodeFlexFecPacket(fecPacketIndex, mediaPackets[0].SequenceNumber)
+		if ok {
+			fecPackets = append(fecPackets, fecPacket)
+		}
 	}
 
 	return fecPackets
 }
 
-func (flex *FlexEncoder03) encodeFlexFecPacket(fecPacketIndex uint32, mediaBaseSn uint16) rtp.Packet {
-	mediaPacketsIt := flex.coverage.GetCoveredBy(fecPacketIndex)
-	flexFecHeader := flex.encodeFlexFecHeader(
-		mediaPacketsIt,
-		flex.coverage.ExtractMask1(fecPacketIndex),
-		flex.coverage.ExtractMask2(fecPacketIndex),
-		flex.coverage.ExtractMask3_03(fecPacketIndex),
-		mediaBaseSn,
-	)
-	flexFecRepairPayload := flex.encodeFlexFecRepairPayload(mediaPacketsIt.Reset())
+//nolint:cyclop
+func (flex *FlexEncoder03) encodeFlexFecPacket(fecPacketIndex uint32, mediaBaseSn uint16) (rtp.Packet, bool) {
+	mediaPackets := flex.coverage.GetCoveredBy(fecPacketIndex)
+	mask1 := flex.coverage.ExtractMask1(fecPacketIndex)
+	optionalMask2 := flex.coverage.ExtractMask2(fecPacketIndex)
+	optionalMask3 := flex.coverage.ExtractMask3_03(fecPacketIndex)
 
-	packet := rtp.Packet{
-		Header: rtp.Header{
-			Version:        2,
-			Padding:        false,
-			Extension:      false,
-			Marker:         false,
-			PayloadType:    flex.payloadType,
-			SequenceNumber: flex.fecBaseSn,
-			Timestamp:      54243243,
-			SSRC:           flex.ssrc,
-			CSRC:           []uint32{},
-		},
-		Payload: append(flexFecHeader, flexFecRepairPayload...),
-	}
-	flex.fecBaseSn++
-
-	return packet
-}
-
-func (flex *FlexEncoder03) encodeFlexFecHeader( //nolint:cyclop
-	mediaPackets *util.MediaPacketIterator,
-	mask1 uint16,
-	optionalMask2 uint32,
-	optionalMask3 uint64,
-	mediaBaseSn uint16,
-) []byte {
 	/*
+	    FlexFEC Header Format:
 	    0                   1                   2                   3
 	    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -140,6 +125,10 @@ func (flex *FlexEncoder03) encodeFlexFecHeader( //nolint:cyclop
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	*/
 
+	if !mediaPackets.HasNext() {
+		return rtp.Packet{}, false
+	}
+
 	// Get header size - This depends on the size of the bitmask.
 	headerSize := BaseFec03HeaderSize
 	if optionalMask2 > 0 || optionalMask3 > 0 {
@@ -149,23 +138,33 @@ func (flex *FlexEncoder03) encodeFlexFecHeader( //nolint:cyclop
 		headerSize += 8
 	}
 
-	// Allocate the FlexFec header
-	flexFecHeader := make([]byte, headerSize)
+	// Find the maximum payload size among all media packets
+	maxPayloadSize := 0
+	for mediaPackets.HasNext() {
+		maxPayloadSize = maxInt(maxPayloadSize, mediaPackets.Next().MarshalSize()-BaseRTPHeaderSize)
+	}
+	mediaPackets.Reset()
 
-	// We allocate a single temporary buffer to store the mediaPacket bytes. This reduces
-	// overall allocations.
-	tmpMediaPacketBuf := make([]byte, 0)
+	flexFecPayload := make([]byte, headerSize+maxPayloadSize)
+
+	flexFecHeader := flexFecPayload[:headerSize]
+	flexFecRepairPayload := flexFecPayload[headerSize : headerSize+maxPayloadSize]
+
+	bufferFromPool := bufferPool.Get().(*[]byte) //nolint:forcetypeassert
+	defer bufferPool.Put(bufferFromPool)
+	tmpMediaPacketBuf := *bufferFromPool
+
 	for mediaPackets.HasNext() {
 		mediaPacket := mediaPackets.Next()
-
-		if mediaPacket.MarshalSize() > len(tmpMediaPacketBuf) {
-			// The temporary buffer is too small, we need to resize.
-			tmpMediaPacketBuf = make([]byte, mediaPacket.MarshalSize())
+		packetSize := mediaPacket.MarshalSize()
+		if packetSize > len(tmpMediaPacketBuf) {
+			// Packet is too large for our fixed buffer, fallback to dynamic allocation
+			tmpMediaPacketBuf = make([]byte, packetSize)
 		}
-		n, err := mediaPacket.MarshalTo(tmpMediaPacketBuf)
 
+		n, err := mediaPacket.MarshalTo(tmpMediaPacketBuf[:packetSize])
 		if n == 0 || err != nil {
-			return nil
+			return rtp.Packet{}, false
 		}
 
 		// XOR the first 2 bytes of the header: V, P, X, CC, M, PT fields
@@ -185,6 +184,11 @@ func (flex *FlexEncoder03) encodeFlexFecHeader( //nolint:cyclop
 		flexFecHeader[5] ^= tmpMediaPacketBuf[5]
 		flexFecHeader[6] ^= tmpMediaPacketBuf[6]
 		flexFecHeader[7] ^= tmpMediaPacketBuf[7]
+
+		// Process FlexFEC Repair Payload (bytes after RTP header)
+		for byteIndex := 0; byteIndex < packetSize-BaseRTPHeaderSize; byteIndex++ {
+			flexFecRepairPayload[byteIndex] ^= tmpMediaPacketBuf[byteIndex+BaseRTPHeaderSize]
+		}
 	}
 
 	// Write the SSRC count
@@ -206,50 +210,40 @@ func (flex *FlexEncoder03) encodeFlexFecHeader( //nolint:cyclop
 
 	if optionalMask2 == 0 && optionalMask3 == 0 {
 		flexFecHeader[18] |= 0b10000000
-
-		return flexFecHeader
-	}
-	binary.BigEndian.PutUint32(flexFecHeader[20:24], optionalMask2)
-
-	if optionalMask3 == 0 {
-		flexFecHeader[20] |= 0b10000000
 	} else {
-		binary.BigEndian.PutUint64(flexFecHeader[24:32], optionalMask3)
-		flexFecHeader[24] |= 0b10000000
+		binary.BigEndian.PutUint32(flexFecHeader[20:24], optionalMask2)
+
+		if optionalMask3 == 0 {
+			flexFecHeader[20] |= 0b10000000
+		} else {
+			binary.BigEndian.PutUint64(flexFecHeader[24:32], optionalMask3)
+			flexFecHeader[24] |= 0b10000000
+		}
 	}
 
-	return flexFecHeader
+	packet := rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Padding:        false,
+			Extension:      false,
+			Marker:         false,
+			PayloadType:    flex.payloadType,
+			SequenceNumber: flex.fecBaseSn,
+			Timestamp:      54243243,
+			SSRC:           flex.ssrc,
+			CSRC:           []uint32{},
+		},
+		Payload: flexFecPayload,
+	}
+	flex.fecBaseSn++
+
+	return packet, true
 }
 
-func (flex *FlexEncoder03) encodeFlexFecRepairPayload(mediaPackets *util.MediaPacketIterator) []byte {
-	flexFecPayload := make([]byte, mediaPackets.First().MarshalSize()-BaseRTPHeaderSize)
-	tmpMediaPacketBuf := make([]byte, 0)
-
-	for mediaPackets.HasNext() {
-		mediaPacket := mediaPackets.Next()
-
-		if mediaPacket.MarshalSize() > len(tmpMediaPacketBuf) {
-			tmpMediaPacketBuf = make([]byte, mediaPacket.MarshalSize())
-		}
-
-		n, err := mediaPacket.MarshalTo(tmpMediaPacketBuf)
-
-		if n == 0 || err != nil {
-			return nil
-		}
-
-		if len(flexFecPayload) < mediaPacket.MarshalSize()-BaseRTPHeaderSize {
-			// Expected FEC packet payload is bigger that what we can currently store,
-			// we need to resize.
-			flexFecPayloadTmp := make([]byte, mediaPacket.MarshalSize()-BaseRTPHeaderSize)
-			copy(flexFecPayloadTmp, flexFecPayload)
-			flexFecPayload = flexFecPayloadTmp
-		}
-
-		for byteIndex := 0; byteIndex < mediaPacket.MarshalSize()-BaseRTPHeaderSize; byteIndex++ {
-			flexFecPayload[byteIndex] ^= tmpMediaPacketBuf[byteIndex+BaseRTPHeaderSize]
-		}
+func maxInt(a, b int) int {
+	if a > b {
+		return a
 	}
 
-	return flexFecPayload
+	return b
 }


### PR DESCRIPTION
#### Description

Reduces allocations and `MarshalSize()` calls

```
goos: darwin
goarch: arm64
pkg: github.com/pion/interceptor/pkg/flexfec
cpu: Apple M1 Pro
BenchmarkFlexEncoder03_EncodeFec/Small_2FEC-10     	 1000000	      1093 ns/op	     720 B/op	      15 allocs/op
BenchmarkFlexEncoder03_EncodeFec/Medium_3FEC-10    	  607994	      2002 ns/op	    1168 B/op	      22 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManySmall_2FEC-10         	   79545	     15077 ns/op	    5312 B/op	      69 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManyMedium_3FEC-10        	   17115	     69868 ns/op	   22536 B/op	     103 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManyLarge_2FEC-10         	    3204	    374434 ns/op	  125714 B/op	     129 allocs/op
PASS
ok  	github.com/pion/interceptor/pkg/flexfec	7.077s


goos: darwin
goarch: arm64
pkg: github.com/pion/interceptor/pkg/flexfec
cpu: Apple M1 Pro
BenchmarkFlexEncoder03_EncodeFec/Small_2FEC-10     	 2387191	       491.7 ns/op	     528 B/op	       7 allocs/op
BenchmarkFlexEncoder03_EncodeFec/Medium_3FEC-10    	 1358226	       888.0 ns/op	     880 B/op	      10 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManySmall_2FEC-10         	  595310	      1994 ns/op	     768 B/op	       7 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManyMedium_3FEC-10        	  211342	      5619 ns/op	    1793 B/op	      10 allocs/op
BenchmarkFlexEncoder03_EncodeFecVaryingSizes/ManyLarge_2FEC-10         	   53484	     22398 ns/op	    2785 B/op	       7 allocs/op
PASS
ok  	github.com/pion/interceptor/pkg/flexfec	7.876s
```
