### PR TITLE
Add PayloadToMimeType map to StreamInfo

### DIFF
--- a/streaminfo.go
+++ b/streaminfo.go
@@ -25,6 +25,7 @@ type StreamInfo struct {
 	Channels                          uint16
 	SDPFmtpLine                       string
 	RTCPFeedback                      []RTCPFeedback
+	Codecs                            []RTPCodecParameters
 }
 
 // RTCPFeedback signals the connection to use additional RTCP packet types.
@@ -38,4 +39,18 @@ type RTCPFeedback struct {
 	// The parameter value depends on the type.
 	// For example, type="nack" parameter="pli" will send Picture Loss Indicator packets.
 	Parameter string
+}
+
+// RTPCodecParameters is a sequence containing the media codecs that an RtpSender
+// will choose from, as well as entries for RTX, RED and FEC mechanisms. This also
+// includes the PayloadType that has been negotiated
+//
+// https://w3c.github.io/webrtc-pc/#rtcrtpcodecparameters
+type RTPCodecParameters struct {
+	MimeType     string
+	ClockRate    uint32
+	Channels     uint16
+	SDPFmtpLine  string
+	RTCPFeedback []RTCPFeedback
+	PayloadType  uint8
 }

--- a/streaminfo.go
+++ b/streaminfo.go
@@ -25,7 +25,7 @@ type StreamInfo struct {
 	Channels                          uint16
 	SDPFmtpLine                       string
 	RTCPFeedback                      []RTCPFeedback
-	Codecs                            []RTPCodecParameters
+	PayloadToMimeType                 map[uint8]string
 }
 
 // RTCPFeedback signals the connection to use additional RTCP packet types.
@@ -39,18 +39,4 @@ type RTCPFeedback struct {
 	// The parameter value depends on the type.
 	// For example, type="nack" parameter="pli" will send Picture Loss Indicator packets.
 	Parameter string
-}
-
-// RTPCodecParameters is a sequence containing the media codecs that an RtpSender
-// will choose from, as well as entries for RTX, RED and FEC mechanisms. This also
-// includes the PayloadType that has been negotiated
-//
-// https://w3c.github.io/webrtc-pc/#rtcrtpcodecparameters
-type RTPCodecParameters struct {
-	MimeType     string
-	ClockRate    uint32
-	Channels     uint16
-	SDPFmtpLine  string
-	RTCPFeedback []RTCPFeedback
-	PayloadType  uint8
 }


### PR DESCRIPTION
#### Description
This issue arose during the implementation of a RED FEC decoder interceptor. A sender can announce both an original codec (Opus, in this example) and RED in the SDP as follows:

```
a=rtpmap:111 opus/48000/2
a=fmtp:111 minptime=10;useinbandfec=1;usedtx=1
a=rtpmap:63 red/48000/2
a=fmtp:63 111/111
```

Following this announcement, the sender may or may not use RED for audio transmission. Furthermore, the sender can dynamically switch between unprotected Opus and RED-protected streams during a session.

Currently, the receiver's interceptor has no way to determine the MIME type of a received packet. The StreamInfo structure only contains the capabilities of the first negotiated codec for the media section, which is not always the codec being used for transmission.

This PR resolves this ambiguity by adding a PayloadToMimeType map to StreamInfo. This allows decoder interceptors to match a received packet's payload type to its corresponding MIME type. For instance, with this change, the RED FEC decoder interceptor can now reliably differentiate between unprotected audio packets and RED-protected audio packets.

#### Implementation PR

The PayloadToMimeType field is set within the pion/webrtc repository. The work is handled by the following pull request: [pion/webrtc#3175](https://github.com/pion/webrtc/pull/3175)

This corresponding PR is currently a draft because it depends on the changes from this PR. Once this is merged, the pion/webrtc PR will be updated with a commit that bumps its dependency on this repository to include these changes, and it can then be finalized for review.