### PR TITLE
Allow users to provide a custom logger implementation

### DIFF
--- a/pkg/packetdump/default_packet_logger.go
+++ b/pkg/packetdump/default_packet_logger.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package packetdump
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/logging"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+type defaultPacketLogger struct {
+	log logging.LeveledLogger
+
+	wg    sync.WaitGroup
+	close chan struct{}
+
+	rtpChan  chan *rtpDump
+	rtcpChan chan *rtcpDump
+
+	rtpStream  io.Writer
+	rtcpStream io.Writer
+
+	rtpFormatBinary  RTPBinaryFormatCallback
+	rtcpFormatBinary RTCPBinaryFormatCallback
+
+	rtpFormat  RTPFormatCallback
+	rtcpFormat RTCPFormatCallback
+
+	rtpFilter           RTPFilterCallback
+	rtcpFilter          RTCPFilterCallback
+	rtcpPerPacketFilter RTCPPerPacketFilterCallback
+}
+
+func (d *defaultPacketLogger) run() {
+	d.wg.Add(1)
+	go d.loop()
+}
+
+func (d *defaultPacketLogger) LogRTPPacket(header *rtp.Header, payload []byte, attributes interceptor.Attributes) {
+	select {
+	case d.rtpChan <- &rtpDump{
+		attributes: attributes,
+		packet: &rtp.Packet{
+			Header:  *header,
+			Payload: payload,
+		},
+	}:
+	case <-d.close:
+	}
+}
+
+func (d *defaultPacketLogger) LogRTCPPackets(pkts []rtcp.Packet, attributes interceptor.Attributes) {
+	select {
+	case d.rtcpChan <- &rtcpDump{
+		attributes: attributes,
+		packets:    pkts,
+	}:
+	case <-d.close:
+	}
+}
+
+func (d *defaultPacketLogger) writeDumpedRTP(dump *rtpDump) error {
+	if !d.rtpFilter(dump.packet) {
+		return nil
+	}
+
+	if d.rtpFormatBinary != nil {
+		dumped, err := d.rtpFormatBinary(dump.packet, dump.attributes)
+		if err != nil {
+			return fmt.Errorf("rtp format binary: %w", err)
+		}
+		_, err = d.rtpStream.Write(dumped)
+		if err != nil {
+			return fmt.Errorf("rtp stream write: %w", err)
+		}
+	}
+
+	if d.rtpFormat != nil {
+		if _, err := fmt.Fprint(d.rtpStream, d.rtpFormat(dump.packet, dump.attributes)); err != nil {
+			return fmt.Errorf("rtp stream Fprint: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (d *defaultPacketLogger) writeDumpedRTCP(dump *rtcpDump) error {
+	if !d.rtcpFilter(dump.packets) {
+		return nil
+	}
+
+	for _, pkt := range dump.packets {
+		if !d.rtcpPerPacketFilter(pkt) {
+			continue
+		}
+
+		if d.rtcpFormatBinary != nil {
+			dumped, err := d.rtcpFormatBinary(pkt, dump.attributes)
+			if err != nil {
+				return fmt.Errorf("rtcp format binary: %w", err)
+			}
+
+			_, err = d.rtcpStream.Write(dumped)
+			if err != nil {
+				return fmt.Errorf("rtcp stream write: %w", err)
+			}
+		}
+	}
+
+	if d.rtcpFormat != nil {
+		if _, err := fmt.Fprint(d.rtcpStream, d.rtcpFormat(dump.packets, dump.attributes)); err != nil {
+			return fmt.Errorf("rtcp stream Fprint: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Close closes the PacketDumper.
+func (d *defaultPacketLogger) Close() error {
+	defer d.wg.Wait()
+
+	if !d.isClosed() {
+		close(d.close)
+	}
+
+	return nil
+}
+
+func (d *defaultPacketLogger) isClosed() bool {
+	select {
+	case <-d.close:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *defaultPacketLogger) loop() {
+	defer d.wg.Done()
+
+	for {
+		select {
+		case <-d.close:
+			return
+		case dump := <-d.rtpChan:
+			err := d.writeDumpedRTP(dump)
+			if err != nil {
+				d.log.Errorf("could not dump RTP packet: %v", err)
+			}
+		case dump := <-d.rtcpChan:
+			err := d.writeDumpedRTCP(dump)
+			if err != nil {
+				d.log.Errorf("could not dump RTCP packets: %v", err)
+			}
+		}
+	}
+}

--- a/pkg/packetdump/option.go
+++ b/pkg/packetdump/option.go
@@ -21,7 +21,18 @@ func Log(log logging.LeveledLogger) PacketDumperOption {
 	}
 }
 
-// RTPWriter sets the io.Writer on which RTP packets will be dumped.
+// PacketLog sets the packet logger of a packet dumper. Use this to replace the
+// default logger with yout own logger implementation.
+func PacketLog(logger PacketLogger) PacketDumperOption {
+	return func(d *PacketDumper) error {
+		d.packetLogger = logger
+
+		return nil
+	}
+}
+
+// RTPWriter sets the io.Writer on which RTP packets will be dumped by the
+// default packet logger.
 func RTPWriter(w io.Writer) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtpStream = w
@@ -30,7 +41,8 @@ func RTPWriter(w io.Writer) PacketDumperOption {
 	}
 }
 
-// RTCPWriter sets the io.Writer on which RTCP packets will be dumped.
+// RTCPWriter sets the io.Writer on which RTCP packets will be dumped by the
+// default packet logger.
 func RTCPWriter(w io.Writer) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpStream = w
@@ -39,7 +51,7 @@ func RTCPWriter(w io.Writer) PacketDumperOption {
 	}
 }
 
-// RTPFormatter sets the RTP format
+// RTPFormatter sets the RTP format used by the default packet logger.
 // Deprecated: prefer RTPBinaryFormatter.
 func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
@@ -49,7 +61,7 @@ func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 	}
 }
 
-// RTCPFormatter sets the RTCP format
+// RTCPFormatter sets the RTCP format used by the default packet logger.
 // Deprecated: prefer RTCPBinaryFormatter.
 func RTCPFormatter(f RTCPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
@@ -59,7 +71,8 @@ func RTCPFormatter(f RTCPFormatCallback) PacketDumperOption {
 	}
 }
 
-// RTPBinaryFormatter sets the RTP binary formatter.
+// RTPBinaryFormatter sets the RTP binary formatter used by the default packet
+// logger.
 func RTPBinaryFormatter(f RTPBinaryFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtpFormatBinary = f
@@ -68,7 +81,8 @@ func RTPBinaryFormatter(f RTPBinaryFormatCallback) PacketDumperOption {
 	}
 }
 
-// RTCPBinaryFormatter sets the RTCP binary formatter.
+// RTCPBinaryFormatter sets the RTCP binary formatter used by the default packet
+// logger.
 func RTCPBinaryFormatter(f RTCPBinaryFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpFormatBinary = f
@@ -77,7 +91,7 @@ func RTCPBinaryFormatter(f RTCPBinaryFormatCallback) PacketDumperOption {
 	}
 }
 
-// RTPFilter sets the RTP filter.
+// RTPFilter sets the RTP filter used by the default packet logger.
 func RTPFilter(callback RTPFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtpFilter = callback
@@ -86,7 +100,7 @@ func RTPFilter(callback RTPFilterCallback) PacketDumperOption {
 	}
 }
 
-// RTCPFilter sets the RTCP filter.
+// RTCPFilter sets the RTCP filter used by the default packet logger.
 // Deprecated: prefer RTCPPerPacketFilter.
 func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
@@ -96,7 +110,8 @@ func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	}
 }
 
-// RTCPPerPacketFilter sets the RTCP per-packet filter.
+// RTCPPerPacketFilter sets the RTCP per-packet filter used by the default
+// packet logger.
 func RTCPPerPacketFilter(callback RTCPPerPacketFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
 		d.rtcpPerPacketFilter = callback

--- a/pkg/packetdump/packet_dumper_test.go
+++ b/pkg/packetdump/packet_dumper_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package packetdump
+
+import (
+	"testing"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+)
+
+type customLogger struct {
+	rtpLog  chan rtpDump
+	rtcpLog chan rtcpDump
+}
+
+// LogRTCPPackets implements PacketLogger.
+func (c *customLogger) LogRTCPPackets(pkts []rtcp.Packet, attributes interceptor.Attributes) {
+	c.rtcpLog <- rtcpDump{
+		attributes: attributes,
+		packets:    pkts,
+	}
+}
+
+// LogRTPPacket implements PacketLogger.
+func (c *customLogger) LogRTPPacket(header *rtp.Header, payload []byte, attributes interceptor.Attributes) {
+	c.rtpLog <- rtpDump{
+		attributes: attributes,
+		packet: &rtp.Packet{
+			Header:  *header,
+			Payload: payload,
+		},
+	}
+}
+
+func TestCustomLogger(t *testing.T) {
+	cl := &customLogger{
+		rtpLog:  make(chan rtpDump, 1),
+		rtcpLog: make(chan rtcpDump, 1),
+	}
+	dumper, err := NewPacketDumper(PacketLog(cl))
+	assert.NoError(t, err)
+	dumper.logRTPPacket(&rtp.Header{}, []byte{1, 2, 3, 4}, nil)
+	dumper.logRTCPPackets([]rtcp.Packet{
+		&rtcp.RawPacket{0, 1, 2, 3},
+	}, nil)
+
+	rtpL := <-cl.rtpLog
+	assert.Equal(t, rtpDump{
+		attributes: nil,
+		packet: &rtp.Packet{
+			Header:  rtp.Header{},
+			Payload: []byte{1, 2, 3, 4},
+		},
+	}, rtpL)
+	rtcpL := <-cl.rtcpLog
+	assert.Equal(t, rtcpDump{
+		attributes: nil,
+		packets: []rtcp.Packet{
+			&rtcp.RawPacket{0, 1, 2, 3},
+		},
+	}, rtcpL)
+}

--- a/pkg/packetdump/packet_logger.go
+++ b/pkg/packetdump/packet_logger.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package packetdump
+
+import (
+	"github.com/pion/interceptor"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+type PacketLogger interface {
+	LogRTPPacket(header *rtp.Header, payload []byte, attributes interceptor.Attributes)
+	LogRTCPPackets(pkts []rtcp.Packet, attributes interceptor.Attributes)
+}


### PR DESCRIPTION
#### Description

The current implementation allows users to specify custom writers and custom formatters. But now Go has built-in structured logging, so I would like to do something like this:
```
slog.Info("received RTP packet", "sequence-number", pkt.header.SequenceNumber)
```

I think this is not possible with the current implementation. This PR allows me to provide a custom logger that can then implement any form of custom logging.