### PR TITLE
Rename and deprecated rfc8888 package

### DIFF
--- a/pkg/ccfb/interceptor.go
+++ b/pkg/ccfb/interceptor.go
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-// Package rfc8888 provides an interceptor that generates congestion control
+// Package ccfb provides an interceptor that generates congestion control
 // feedback reports as defined by RFC 8888.
-package rfc8888
+package ccfb
 
 import (
 	"errors"
@@ -52,7 +52,7 @@ func (s *SenderInterceptorFactory) NewInterceptor(_ string) (interceptor.Interce
 		senderInterceptor.loggerFactory = logging.NewDefaultLoggerFactory()
 	}
 	if senderInterceptor.log == nil {
-		senderInterceptor.log = senderInterceptor.loggerFactory.NewLogger("rfc8888_interceptor")
+		senderInterceptor.log = senderInterceptor.loggerFactory.NewLogger("ccfb_interceptor")
 	}
 
 	return senderInterceptor, nil

--- a/pkg/ccfb/interceptor_test.go
+++ b/pkg/ccfb/interceptor_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"sync"

--- a/pkg/ccfb/option.go
+++ b/pkg/ccfb/option.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"time"

--- a/pkg/ccfb/recorder.go
+++ b/pkg/ccfb/recorder.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"time"

--- a/pkg/ccfb/recorder_test.go
+++ b/pkg/ccfb/recorder_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"math/rand"

--- a/pkg/ccfb/stream_log.go
+++ b/pkg/ccfb/stream_log.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"time"

--- a/pkg/ccfb/stream_log_test.go
+++ b/pkg/ccfb/stream_log_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import (
 	"testing"

--- a/pkg/ccfb/ticker.go
+++ b/pkg/ccfb/ticker.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package rfc8888
+package ccfb
 
 import "time"
 

--- a/pkg/rfc8888/rfc8888.go
+++ b/pkg/rfc8888/rfc8888.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package rfc8888 is deprecated. Use ccfb instead.
+package rfc8888
+
+import (
+	"time"
+
+	"github.com/pion/interceptor/pkg/ccfb"
+)
+
+// TickerFactory is a factory to create new tickers.
+//
+// Deprecated: moved to pkg/ccfb.
+type TickerFactory = ccfb.TickerFactory
+
+// SenderInterceptorFactory is a interceptor.Factory for a SenderInterceptor.
+//
+// Deprecated: moved to pkg/ccfb.
+type SenderInterceptorFactory = ccfb.SenderInterceptorFactory
+
+// Deprecated: moved to pkg/ccfb.
+func NewSenderInterceptor(opts ...Option) (*SenderInterceptorFactory, error) {
+	oo := []ccfb.Option{}
+	oo = append(oo, opts...)
+
+	return ccfb.NewSenderInterceptor(oo...)
+}
+
+// SenderInterceptor sends congestion control feedback as specified in RFC 8888.
+//
+// Deprecated: moved to pkg/ccfb.
+type SenderInterceptor = ccfb.SenderInterceptor
+
+// An Option is a function that can be used to configure a SenderInterceptor.
+//
+// Deprecated: moved to pkg/ccfb.
+type Option = ccfb.Option
+
+// Deprecated: moved to pkg/ccfb.
+func SenderTicker(f TickerFactory) Option {
+	return ccfb.SenderTicker(f)
+}
+
+// Deprecated: moved to pkg/ccfb.
+func SenderNow(f func() time.Time) Option {
+	return ccfb.SenderNow(f)
+}
+
+// Deprecated: moved to pkg/ccfb.
+func SendInterval(interval time.Duration) Option {
+	return ccfb.SendInterval(interval)
+}
+
+// Recorder records incoming RTP packets and their arrival times. Recorder can
+// be used to create feedback reports as defined by RFC 8888.
+//
+// Deprecated: moved to pkg/ccfb.
+type Recorder = ccfb.Recorder
+
+// Deprecated: moved to pkg/ccfb.
+func NewRecorder() *Recorder {
+	return ccfb.NewRecorder()
+}


### PR DESCRIPTION
Rename `rfc8888` packages. We don't have any other packages named after the respective RFCs.