### PR TITLE
Fix jitter calculation to match RFC3550 and convert to seconds

### DIFF
--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -32,6 +32,7 @@ type internalStats struct {
 
 	inboundLastArrivalInitialized bool
 	inboundLastArrival            time.Time
+	inboundLastArrivalRTP         uint32
 	inboundLastTransit            int
 
 	remoteInboundFirstSequenceNumberInitialized bool
@@ -137,17 +138,21 @@ func (r *recorder) recordIncomingRTP(latestStats internalStats, incoming *incomi
 
 	if !latestStats.inboundLastArrivalInitialized {
 		latestStats.inboundLastArrival = incoming.ts
+		latestStats.inboundLastArrivalRTP = incoming.header.Timestamp
 		latestStats.inboundLastArrivalInitialized = true
 	} else {
-		arrival := int(incoming.ts.Sub(latestStats.inboundLastArrival).Seconds() * r.clockRate)
-		transit := arrival - int(incoming.header.Timestamp)
+		rtpUnitsSinceLastArrival := incoming.ts.Sub(latestStats.inboundLastArrival).Seconds() * r.clockRate
+		arrival := latestStats.inboundLastArrivalRTP + uint32(rtpUnitsSinceLastArrival)
+		transit := int(arrival) - int(incoming.header.Timestamp)
 		d := transit - latestStats.inboundLastTransit
-		latestStats.inboundLastTransit = transit
 		if d < 0 {
 			d = -d
 		}
-		latestStats.InboundRTPStreamStats.Jitter += (1.0 / 16.0) * (float64(d) - latestStats.InboundRTPStreamStats.Jitter)
+		dSec := float64(d) / r.clockRate
+		latestStats.inboundLastTransit = transit
+		latestStats.InboundRTPStreamStats.Jitter += (1.0 / 16.0) * (dSec - latestStats.InboundRTPStreamStats.Jitter)
 		latestStats.inboundLastArrival = incoming.ts
+		latestStats.inboundLastArrivalRTP = incoming.header.Timestamp
 	}
 
 	latestStats.LastPacketReceivedTimestamp = incoming.ts

--- a/pkg/stats/stats_recorder_test.go
+++ b/pkg/stats/stats_recorder_test.go
@@ -95,7 +95,7 @@ func TestStatsRecorder(t *testing.T) {
 				ReceivedRTPStreamStats: ReceivedRTPStreamStats{
 					PacketsReceived: 3,
 					PacketsLost:     2,
-					Jitter:          90000 / 16,
+					Jitter:          0,
 				},
 				LastPacketReceivedTimestamp: now.Add(2 * time.Second),
 				HeaderBytesReceived:         36,
@@ -788,6 +788,48 @@ func TestStatsRecorder(t *testing.T) {
 				HeaderBytesReceived:         36,
 				BytesReceived:               36,
 				FIRCount:                    0,
+			},
+		},
+		{
+			name: "incomingRTPWithJitter",
+			records: []record{
+				{
+					ts: now,
+					content: incomingRTP{
+						header: rtp.Header{
+							SequenceNumber: 7,
+							Timestamp:      0,
+						},
+					},
+				},
+				{
+					ts: now.Add(1 * time.Second),
+					content: incomingRTP{
+						header: rtp.Header{
+							SequenceNumber: 8,
+							Timestamp:      90000,
+						},
+					},
+				},
+				{
+					ts: now.Add(2*time.Second + 100*time.Millisecond),
+					content: incomingRTP{
+						header: rtp.Header{
+							SequenceNumber: 9,
+							Timestamp:      2 * 90000,
+						},
+					},
+				},
+			},
+			expectedInboundRTPStreamStats: InboundRTPStreamStats{
+				ReceivedRTPStreamStats: ReceivedRTPStreamStats{
+					PacketsReceived: 3,
+					PacketsLost:     0,
+					Jitter:          0.00625,
+				},
+				LastPacketReceivedTimestamp: now.Add(2*time.Second + 100*time.Millisecond),
+				HeaderBytesReceived:         36,
+				BytesReceived:               36,
 			},
 		},
 	} {


### PR DESCRIPTION
#### Description
The previous jitter calculation was not following RFC3550 and reported incorrect values, as can be seen in the first modified test which reports a high jitter despite all packets arriving perfectly spaced (in both RTP timestamp and Pion receival timestamp).
Additionally, other implementations report the jitter in seconds instead of RTP timestamp units which are dependent on the streams clock rate, which should now also be the case here.

#### Reference issue
Fixes #234 
