### PR TITLE
Preallocate slice capacity in Registry.Build()

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -19,7 +19,7 @@ func (r *Registry) Build(id string) (Interceptor, error) {
 		return &NoOp{}, nil
 	}
 
-	interceptors := []Interceptor{}
+	interceptors := make([]Interceptor, 0, len(r.factories))
 	for _, f := range r.factories {
 		i, err := f.NewInterceptor(id)
 		if err != nil {


### PR DESCRIPTION
Optimize memory allocation by preallocating interceptors slice with known capacity to avoid multiple reallocations during append operations.