### PR TITLE
Use Go 1.21 built-in min function

### DIFF
--- a/pkg/flexfec/flexfec_decoder_03.go
+++ b/pkg/flexfec/flexfec_decoder_03.go
@@ -283,7 +283,7 @@ func (d *fecDecoder) recoverPacket(fec *fecPacketState) (rtp.Packet, error) {
 			if err != nil {
 				return rtp.Packet{}, fmt.Errorf("marshal protected packet: %w", err)
 			}
-			for i := 0; i < minInt(int(payloadLength), len(packet)-12); i++ {
+			for i := 0; i < min(int(payloadLength), len(packet)-12); i++ {
 				payloadRecovery[i] ^= packet[12+i]
 			}
 		}
@@ -407,23 +407,7 @@ func parseFlexFEC03Header(data []byte) (flexFec, error) {
 }
 
 func seqDiff(a, b uint16) uint16 {
-	return minUInt16(a-b, b-a)
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-func minUInt16(a, b uint16) uint16 {
-	if a < b {
-		return a
-	}
-
-	return b
+	return min(a-b, b-a)
 }
 
 func abs(x int) int {

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -66,7 +66,7 @@ func (a *adaptiveThreshold) compare(estimate, _ time.Duration) (usage, time.Dura
 	if a.numDeltas < 2 {
 		return usageNormal, estimate, a.max
 	}
-	t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
+	t := time.Duration(min(a.numDeltas, maxDeltas)) * estimate
 	use := usageNormal
 	if t > a.thresh {
 		use = usageOver
@@ -96,7 +96,7 @@ func (a *adaptiveThreshold) update(estimate time.Duration) {
 	}
 	maxTimeDelta := 100 * time.Millisecond
 	timeDelta := time.Duration(
-		minInt(int(now.Sub(a.lastUpdate).Milliseconds()), int(maxTimeDelta.Milliseconds())),
+		min(int(now.Sub(a.lastUpdate).Milliseconds()), int(maxTimeDelta.Milliseconds())),
 	) * time.Millisecond
 	d := absEstimate - a.thresh
 	add := k * float64(d.Milliseconds()) * float64(timeDelta.Milliseconds())

--- a/pkg/gcc/gcc.go
+++ b/pkg/gcc/gcc.go
@@ -6,14 +6,6 @@ package gcc
 
 import "time"
 
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
 func maxInt(a, b int) int {
 	if a > b {
 		return a
@@ -23,7 +15,7 @@ func maxInt(a, b int) int {
 }
 
 func clampInt(b, minVal, maxVal int) int {
-	return maxInt(minVal, minInt(maxVal, b))
+	return maxInt(minVal, min(maxVal, b))
 }
 
 func clampDuration(d, minVal, maxVal time.Duration) time.Duration {

--- a/pkg/gcc/gcc_test.go
+++ b/pkg/gcc/gcc_test.go
@@ -11,35 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMinInt(t *testing.T) {
-	tests := []struct {
-		expected int
-		a, b     int
-	}{
-		{
-			expected: 0,
-			a:        0,
-			b:        100,
-		},
-		{
-			expected: 10,
-			a:        10,
-			b:        10,
-		},
-		{
-			expected: 1,
-			a:        10,
-			b:        1,
-		},
-	}
-	for i, tt := range tests {
-		tt := tt
-		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			assert.Equal(t, tt.expected, minInt(tt.a, tt.b))
-		})
-	}
-}
-
 func TestMaxInt(t *testing.T) {
 	tests := []struct {
 		expected int

--- a/pkg/gcc/loss_based_bwe.go
+++ b/pkg/gcc/loss_based_bwe.go
@@ -63,7 +63,7 @@ func (e *lossBasedBandwidthEstimator) getEstimate(wantedRate int) LossStats {
 	if e.bitrate <= 0 {
 		e.bitrate = clampInt(wantedRate, e.minBitrate, e.maxBitrate)
 	}
-	e.bitrate = minInt(wantedRate, e.bitrate)
+	e.bitrate = min(wantedRate, e.bitrate)
 
 	return LossStats{
 		TargetBitrate: e.bitrate,

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -210,7 +210,7 @@ func (e *SendSideBWE) WriteRTCP(pkts []rtcp.Packet, _ interceptor.Attributes) er
 			}
 			pendingTime := feedbackSentTime.Sub(ack.Arrival)
 			rtt := now.Sub(ack.Departure) - pendingTime
-			feedbackMinRTT = time.Duration(minInt(int(rtt), int(feedbackMinRTT)))
+			feedbackMinRTT = time.Duration(min(int(rtt), int(feedbackMinRTT)))
 		}
 		if feedbackMinRTT < math.MaxInt {
 			e.delayController.updateRTT(feedbackMinRTT)
@@ -283,7 +283,7 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 
 	lossStats := e.lossController.getEstimate(delayStats.TargetBitrate)
 	bitrateChanged := false
-	bitrate := minInt(delayStats.TargetBitrate, lossStats.TargetBitrate)
+	bitrate := min(delayStats.TargetBitrate, lossStats.TargetBitrate)
 	if bitrate != e.latestBitrate {
 		bitrateChanged = true
 		e.latestBitrate = bitrate

--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -249,7 +249,7 @@ func (r *recorder) recordIncomingRR(latestStats internalStats, pkt *rtcp.Receive
 		latestStats.RemoteInboundRTPStreamStats.Jitter = float64(report.Jitter) / r.clockRate
 
 		if report.Delay != 0 && report.LastSenderReport != 0 {
-			for i := minInt(r.maxLastSenderReports, len(latestStats.lastSenderReports)) - 1; i >= 0; i-- {
+			for i := min(r.maxLastSenderReports, len(latestStats.lastSenderReports)) - 1; i >= 0; i-- {
 				lastReport := latestStats.lastSenderReports[i]
 				if (lastReport&0x0000FFFFFFFF0000)>>16 == uint64(report.LastSenderReport) {
 					dlsr := time.Duration(float64(report.Delay) / 65536.0 * float64(time.Second))
@@ -272,7 +272,7 @@ func (r *recorder) recordIncomingXR(latestStats internalStats, pkt *rtcp.Extende
 		if xr, ok := report.(*rtcp.DLRRReportBlock); ok {
 			for _, xrReport := range xr.Reports {
 				if xrReport.LastRR != 0 && xrReport.DLRR != 0 {
-					for i := minInt(r.maxLastReceiverReferenceTimes, len(latestStats.lastReceiverReferenceTimes)) - 1; i >= 0; i-- {
+					for i := min(r.maxLastReceiverReferenceTimes, len(latestStats.lastReceiverReferenceTimes)) - 1; i >= 0; i-- {
 						lastRR := latestStats.lastReceiverReferenceTimes[i]
 						if (lastRR&0x0000FFFFFFFF0000)>>16 == uint64(xrReport.LastRR) {
 							dlrr := time.Duration(float64(xrReport.DLRR) / 65536.0 * float64(time.Second))
@@ -406,12 +406,4 @@ func (r *recorder) QueueOutgoingRTCP(ts time.Time, pkts []rtcp.Packet, attr inte
 		attr: attr,
 	})
 	r.ms.Unlock()
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
 }

--- a/pkg/twcc/arrival_time_map.go
+++ b/pkg/twcc/arrival_time_map.go
@@ -136,7 +136,7 @@ func (m *packetArrivalTimeMap) EraseTo(sequenceNumber int64) {
 // RemoveOldPackets removes packets from the beginning of the map as long as they are before
 // sequenceNumber and with an age older than arrivalTimeLimit.
 func (m *packetArrivalTimeMap) RemoveOldPackets(sequenceNumber int64, arrivalTimeLimit int64) {
-	checkTo := min64(sequenceNumber, m.endSequenceNumber)
+	checkTo := min(sequenceNumber, m.endSequenceNumber)
 	for m.beginSequenceNumber < checkTo && m.get(m.beginSequenceNumber) <= arrivalTimeLimit {
 		m.beginSequenceNumber++
 	}

--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -318,7 +318,7 @@ func (c *chunk) encode() rtcp.PacketStatusChunk {
 		}
 	}
 
-	minCap := minInt(maxTwoBitCap, len(c.deltas))
+	minCap := min(maxTwoBitCap, len(c.deltas))
 	svc := &rtcp.StatusVectorChunk{
 		SymbolSize: rtcp.TypeTCCSymbolSizeTwoBit,
 		SymbolList: c.deltas[:minCap],
@@ -356,24 +356,8 @@ func maxInt(a, b int) int {
 	return b
 }
 
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
 func max64(a, b int64) int64 {
 	if a > b {
-		return a
-	}
-
-	return b
-}
-
-func min64(a, b int64) int64 {
-	if a < b {
 		return a
 	}
 


### PR DESCRIPTION
This pull request proposes an update to the Go version, elevating it from 1.20 to 1.21.

This change is dependent on https://github.com/pion/.goassets/pull/233