### PR TITLE
Fix zero-delta case in overuse detector

### DIFF
--- a/pkg/gcc/overuse_detector.go
+++ b/pkg/gcc/overuse_detector.go
@@ -49,13 +49,17 @@ func (d *overuseDetector) onDelayStats(ds DelayStats) {
 		} else {
 			d.increasingDuration += delta
 		}
+
 		d.increasingCounter++
-		if d.increasingDuration > d.overuseTime && d.increasingCounter > 1 {
+
+		if (d.overuseTime == 0 && d.increasingCounter > 1) ||
+			(d.increasingDuration > d.overuseTime && d.increasingCounter > 1) {
 			if estimate > d.lastEstimate {
 				use = usageOver
 			}
 		}
 	}
+
 	if thresholdUse == usageUnder {
 		d.increasingCounter = 0
 		d.increasingDuration = 0
@@ -67,6 +71,7 @@ func (d *overuseDetector) onDelayStats(ds DelayStats) {
 		d.increasingCounter = 0
 		use = usageNormal
 	}
+
 	d.lastEstimate = estimate
 
 	d.dsWriter(DelayStats{


### PR DESCRIPTION
#### Description
Fixes a bug in the overuse detector when the delta is 0. In practice it should always be greater than 0, but the 0 case was incorrect.

#### Reference issue
The issue was found when working on #368 
