### PR TITLE
Update last packet time only on change

### DIFF
--- a/pkg/report/sender_stream.go
+++ b/pkg/report/sender_stream.go
@@ -43,8 +43,12 @@ func (stream *senderStream) processRTP(now time.Time, header *rtp.Header, payloa
 	if stream.useLatestPacket || stream.packetCount == 0 || (diff > 0 && diff < (1<<15)) {
 		// Told to consider every packet, or this was the first packet, or it's in-order
 		stream.lastRTPSN = header.SequenceNumber
-		stream.lastRTPTimeRTP = header.Timestamp
-		stream.lastRTPTimeTime = now
+		// update only on first packet of a frame to ensure sender report does not get affected by
+		// processing delay of pushing a large frame which could span multiple packets
+		if header.Timestamp != stream.lastRTPTimeRTP {
+			stream.lastRTPTimeRTP = header.Timestamp
+			stream.lastRTPTimeTime = now
+		}
 	}
 
 	stream.packetCount++


### PR DESCRIPTION
#### Description
With large samples like key frame, they could be hundreds of packets. Updating the last packet time on each of those packets means the sender report could be off by the amount of time it takes to send the full sample which could be a few ms.
