### PR TITLE
Avoid RTPBuffer allocation

### DIFF
--- a/internal/rtpbuffer/rtpbuffer.go
+++ b/internal/rtpbuffer/rtpbuffer.go
@@ -4,9 +4,7 @@
 // Package rtpbuffer provides a buffer for storing RTP packets
 package rtpbuffer
 
-import (
-	"fmt"
-)
+import "fmt"
 
 const (
 	// Uint16SizeHalf is half of a math.Uint16.
@@ -26,25 +24,30 @@ type RTPBuffer struct {
 
 // NewRTPBuffer constructs a new RTPBuffer.
 func NewRTPBuffer(size uint16) (*RTPBuffer, error) {
-	allowedSizes := make([]uint16, 0)
-	correctSize := false
-	for i := 0; i < 16; i++ {
-		if size == 1<<i {
-			correctSize = true
-
-			break
-		}
-		allowedSizes = append(allowedSizes, 1<<i)
-	}
-
-	if !correctSize {
-		return nil, fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
+	if err := IsBufferSizeValid(size); err != nil {
+		return nil, err
 	}
 
 	return &RTPBuffer{
 		packets: make([]*RetainablePacket, size),
 		size:    size,
 	}, nil
+}
+
+func IsBufferSizeValid(size uint16) error {
+	for i := 0; i < 16; i++ {
+		if size == 1<<i {
+			return nil
+		}
+	}
+
+	// Only build allowedSizes if we actually need the error
+	allowedSizes := make([]uint16, 0)
+	for i := 0; i < 16; i++ {
+		allowedSizes = append(allowedSizes, 1<<i)
+	}
+
+	return fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
 }
 
 // Add places the RetainablePacket in the RTPBuffer.

--- a/internal/rtpbuffer/rtpbuffer.go
+++ b/internal/rtpbuffer/rtpbuffer.go
@@ -5,7 +5,7 @@
 package rtpbuffer
 
 import (
-	"fmt"
+	"github.com/pion/interceptor/internal/validation"
 )
 
 const (
@@ -26,19 +26,8 @@ type RTPBuffer struct {
 
 // NewRTPBuffer constructs a new RTPBuffer.
 func NewRTPBuffer(size uint16) (*RTPBuffer, error) {
-	allowedSizes := make([]uint16, 0)
-	correctSize := false
-	for i := range 16 {
-		if size == 1<<i {
-			correctSize = true
-
-			break
-		}
-		allowedSizes = append(allowedSizes, 1<<i)
-	}
-
-	if !correctSize {
-		return nil, fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
+	if err := validation.IsPowerOfTwo(size); err != nil {
+		return nil, err
 	}
 
 	return &RTPBuffer{

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package validation provides validation utilities for checking input values.
+package validation
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrInvalidSize = errors.New("invalid buffer size")
+
+func IsPowerOfTwo(size uint16) error {
+	for i := range 16 {
+		if size == 1<<i {
+			return nil
+		}
+	}
+
+	// Only build allowedSizes if we actually need the error
+	allowedSizes := make([]uint16, 0)
+	for i := range 16 {
+		allowedSizes = append(allowedSizes, 1<<i)
+	}
+
+	return fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
+}

--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/rtpbuffer"
 	"github.com/pion/logging"
 	"github.com/pion/rtcp"
 )
@@ -39,7 +40,7 @@ func (g *GeneratorInterceptorFactory) NewInterceptor(_ string) (interceptor.Inte
 		}
 	}
 
-	if _, err := newReceiveLog(generatorInterceptor.size); err != nil {
+	if err := rtpbuffer.IsBufferSizeValid(generatorInterceptor.size); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nack/generator_interceptor.go
+++ b/pkg/nack/generator_interceptor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/interceptor/internal/validation"
 	"github.com/pion/logging"
 	"github.com/pion/rtcp"
 )
@@ -45,7 +46,7 @@ func (g *GeneratorInterceptorFactory) NewInterceptor(_ string) (interceptor.Inte
 		generatorInterceptor.log = generatorInterceptor.loggerFactory.NewLogger("nack_generator")
 	}
 
-	if _, err := newReceiveLog(generatorInterceptor.size); err != nil {
+	if err := validation.IsPowerOfTwo(generatorInterceptor.size); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nack/receive_log.go
+++ b/pkg/nack/receive_log.go
@@ -4,7 +4,6 @@
 package nack
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/pion/interceptor/internal/rtpbuffer"
@@ -20,19 +19,8 @@ type receiveLog struct {
 }
 
 func newReceiveLog(size uint16) (*receiveLog, error) {
-	allowedSizes := make([]uint16, 0)
-	correctSize := false
-	for i := 6; i < 16; i++ {
-		if size == 1<<i {
-			correctSize = true
-
-			break
-		}
-		allowedSizes = append(allowedSizes, 1<<i)
-	}
-
-	if !correctSize {
-		return nil, fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
+	if err := rtpbuffer.IsBufferSizeValid(size); err != nil {
+		return nil, err
 	}
 
 	return &receiveLog{

--- a/pkg/nack/receive_log.go
+++ b/pkg/nack/receive_log.go
@@ -4,10 +4,10 @@
 package nack
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/pion/interceptor/internal/rtpbuffer"
+	"github.com/pion/interceptor/internal/validation"
 )
 
 type receiveLog struct {
@@ -20,19 +20,8 @@ type receiveLog struct {
 }
 
 func newReceiveLog(size uint16) (*receiveLog, error) {
-	allowedSizes := make([]uint16, 0)
-	correctSize := false
-	for i := 6; i < 16; i++ {
-		if size == 1<<i {
-			correctSize = true
-
-			break
-		}
-		allowedSizes = append(allowedSizes, 1<<i)
-	}
-
-	if !correctSize {
-		return nil, fmt.Errorf("%w: %d is not a valid size, allowed sizes: %v", ErrInvalidSize, size, allowedSizes)
+	if err := validation.IsPowerOfTwo(size); err != nil {
+		return nil, err
 	}
 
 	return &receiveLog{

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -37,7 +37,7 @@ func (r *ResponderInterceptorFactory) NewInterceptor(_ string) (interceptor.Inte
 		responderInterceptor.packetFactory = rtpbuffer.NewPacketFactoryCopy()
 	}
 
-	if _, err := rtpbuffer.NewRTPBuffer(responderInterceptor.size); err != nil {
+	if err := rtpbuffer.IsBufferSizeValid(responderInterceptor.size); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/interceptor"
 	"github.com/pion/interceptor/internal/rtpbuffer"
+	"github.com/pion/interceptor/internal/validation"
 	"github.com/pion/logging"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
@@ -42,7 +43,7 @@ func (r *ResponderInterceptorFactory) NewInterceptor(_ string) (interceptor.Inte
 		responderInterceptor.packetFactory = rtpbuffer.NewPacketFactoryCopy()
 	}
 
-	if _, err := rtpbuffer.NewRTPBuffer(responderInterceptor.size); err != nil {
+	if err := validation.IsPowerOfTwo(responderInterceptor.size); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION

#### Description

Previously, NewInterceptor validated the RTP buffer size by calling rtpbuffer.NewRTPBuffer
this resulted in unnecessary memory allocations during interceptor construction, even though
the buffer itself was not used at that stage.


#### Reference issue
Fixes #...
