### PR TITLE
Fix deprecation comment formatting

### DIFF
--- a/pkg/packetdump/filter.go
+++ b/pkg/packetdump/filter.go
@@ -14,6 +14,7 @@ type RTPFilterCallback func(pkt *rtp.Packet) bool
 
 // RTCPFilterCallback can be used to filter RTCP packets to dump.
 // The callback returns whether or not to print dump the packet's content.
+//
 // Deprecated: prefer RTCPPerPacketFilterCallback.
 type RTCPFilterCallback func(pkt []rtcp.Packet) bool
 

--- a/pkg/packetdump/format.go
+++ b/pkg/packetdump/format.go
@@ -14,22 +14,26 @@ import (
 // RTPFormatCallback can be used to apply custom formatting to each dumped RTP
 // packet. If new lines should be added after each packet, they must be included
 // in the returned format.
+//
 // Deprecated: prefer RTPBinaryFormatCallback.
 type RTPFormatCallback func(*rtp.Packet, interceptor.Attributes) string
 
 // RTCPFormatCallback can be used to apply custom formatting to each dumped RTCP
 // packet. If new lines should be added after each packet, they must be included
 // in the returned format.
+//
 // Deprecated: prefer RTCPBinaryFormatCallback.
 type RTCPFormatCallback func([]rtcp.Packet, interceptor.Attributes) string
 
 // DefaultRTPFormatter returns the default log format for RTP packets
+//
 // Deprecated: useless export since set by default.
 func DefaultRTPFormatter(pkt *rtp.Packet, _ interceptor.Attributes) string {
 	return fmt.Sprintf("%s\n", pkt)
 }
 
 // DefaultRTCPFormatter returns the default log format for RTCP packets
+//
 // Deprecated: useless export since set by default.
 func DefaultRTCPFormatter(pkts []rtcp.Packet, _ interceptor.Attributes) string {
 	return fmt.Sprintf("%s\n", pkts)

--- a/pkg/packetdump/option.go
+++ b/pkg/packetdump/option.go
@@ -52,6 +52,7 @@ func RTCPWriter(w io.Writer) PacketDumperOption {
 }
 
 // RTPFormatter sets the RTP format used by the default packet logger.
+//
 // Deprecated: prefer RTPBinaryFormatter.
 func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
@@ -62,6 +63,7 @@ func RTPFormatter(f RTPFormatCallback) PacketDumperOption {
 }
 
 // RTCPFormatter sets the RTCP format used by the default packet logger.
+//
 // Deprecated: prefer RTCPBinaryFormatter.
 func RTCPFormatter(f RTCPFormatCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {
@@ -101,6 +103,7 @@ func RTPFilter(callback RTPFilterCallback) PacketDumperOption {
 }
 
 // RTCPFilter sets the RTCP filter used by the default packet logger.
+//
 // Deprecated: prefer RTCPPerPacketFilter.
 func RTCPFilter(callback RTCPFilterCallback) PacketDumperOption {
 	return func(d *PacketDumper) error {


### PR DESCRIPTION
Separate deprecation notices into dedicated paragraphs as required by gocritic linter.