### PR TITLE
Fix logger creation in SenderInterceptorFactory

### DIFF
--- a/pkg/report/sender_interceptor.go
+++ b/pkg/report/sender_interceptor.go
@@ -29,7 +29,6 @@ func (s *SenderInterceptorFactory) NewInterceptor(_ string) (interceptor.Interce
 		newTicker: func(d time.Duration) Ticker {
 			return &timeTicker{time.NewTicker(d)}
 		},
-		log:   logging.NewDefaultLoggerFactory().NewLogger("sender_interceptor"),
 		close: make(chan struct{}),
 	}
 


### PR DESCRIPTION
Default one was always set so provided loggerFactory was not used.
