### PR TITLE
cc: trim OnTransportCCFeedback result to PacketStatusCount

### DIFF
--- a/internal/cc/feedback_adapter.go
+++ b/internal/cc/feedback_adapter.go
@@ -182,6 +182,11 @@ func (f *FeedbackAdapter) OnTransportCCFeedback(
 		}
 	}
 
+	// Discard padding slots from the last StatusVectorChunk.
+	if int(feedback.PacketStatusCount) < len(result) {
+		result = result[:feedback.PacketStatusCount]
+	}
+
 	return result, nil
 }
 

--- a/internal/cc/feedback_adapter_test.go
+++ b/internal/cc/feedback_adapter_test.go
@@ -671,7 +671,7 @@ func TestFeedbackAdapterTWCC(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.NotEmpty(t, results)
-		assert.Len(t, results, 7)
+		assert.Len(t, results, 2)
 		assert.Contains(t, results, Acknowledgment{
 			SequenceNumber: 65535,
 			Size:           pkt65535.Header.MarshalSize() + 1200,
@@ -739,21 +739,13 @@ func TestFeedbackAdapterTWCC(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		assert.Len(t, results, 7)
+		assert.Len(t, results, 3)
 		for i := range uint16(3) {
 			assert.Contains(t, results, Acknowledgment{
 				SequenceNumber: i,
 				Size:           headers[i].MarshalSize() + 1200,
 				Departure:      t0,
 				Arrival:        t0.Add(time.Duration((i + 1)) * 4 * time.Microsecond),
-			})
-		}
-		for i := uint16(3); i < 7; i++ {
-			assert.Contains(t, results, Acknowledgment{
-				SequenceNumber: i,
-				Size:           headers[i].MarshalSize() + 1200,
-				Departure:      t0,
-				Arrival:        time.Time{},
 			})
 		}
 	})
@@ -858,7 +850,7 @@ func TestFeedbackAdapterTWCC(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Len(t, packets, 14)
+		assert.Len(t, packets, 3)
 	})
 
 	t.Run("mixedRunLengthAndStatusVector", func(t *testing.T) {


### PR DESCRIPTION
StatusVectorChunks always encode a fixed number of slots (7 for 2-bit symbols, 14 for 1-bit). When the number of reported packets does not fill the final chunk, the encoder pads the remaining slots with TypeTCCPacketNotReceived symbols.

Without trimming, those padding slots are looked up in the send history and, if found (e.g. recently sent packets whose SNs happen to fall in the padding range), are returned as Acknowledgments with a zero Arrival time. The loss estimator then counts them as lost packets, inflating the loss estimate even though those packets are still in flight.
