### PR TITLE
Read reception reports from sender report packets

### DIFF
--- a/pkg/stats/stats_recorder.go
+++ b/pkg/stats/stats_recorder.go
@@ -236,8 +236,12 @@ func (r *recorder) recordOutgoingRTP(latestStats internalStats, v *outgoingRTP) 
 	return latestStats
 }
 
-func (r *recorder) recordIncomingRR(latestStats internalStats, pkt *rtcp.ReceiverReport, ts time.Time) internalStats {
-	for _, report := range pkt.Reports {
+func (r *recorder) recordIncomingRR(
+	latestStats internalStats,
+	reports []rtcp.ReceptionReport,
+	ts time.Time,
+) internalStats {
+	for _, report := range reports {
 		if latestStats.remoteInboundFirstSequenceNumberInitialized {
 			cycles := uint64(report.LastSequenceNumber&0xFFFF0000) >> 16
 			nr := uint64(report.LastSequenceNumber & 0x0000FFFF)
@@ -312,12 +316,13 @@ func (r *recorder) recordIncomingRTCP(latestStats internalStats, incoming *incom
 		case *rtcp.PictureLossIndication:
 			latestStats.OutboundRTPStreamStats.PLICount++
 		case *rtcp.ReceiverReport:
-			latestStats = r.recordIncomingRR(latestStats, pkt, incoming.ts)
+			latestStats = r.recordIncomingRR(latestStats, pkt.Reports, incoming.ts)
 		case *rtcp.SenderReport:
 			latestStats.RemoteOutboundRTPStreamStats.PacketsSent = uint64(pkt.PacketCount)
 			latestStats.RemoteOutboundRTPStreamStats.BytesSent = uint64(pkt.OctetCount)
 			latestStats.RemoteTimeStamp = ntp.ToTime(pkt.NTPTime)
 			latestStats.ReportsSent++
+			latestStats = r.recordIncomingRR(latestStats, pkt.Reports, incoming.ts)
 
 		case *rtcp.ExtendedReport:
 			return r.recordIncomingXR(latestStats, pkt, incoming.ts)

--- a/pkg/stats/stats_recorder_test.go
+++ b/pkg/stats/stats_recorder_test.go
@@ -927,6 +927,68 @@ func TestStatsRecorder(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Copy of basicOutgoingRTP but with RR embedded in a SR
+			name: "readRRinSR",
+			records: []record{
+				{
+					ts: now,
+					content: outgoingRTP{
+						header: rtp.Header{
+							SequenceNumber: 1,
+						},
+					},
+				},
+				{
+					ts: now,
+					content: outgoingRTP{
+						header: rtp.Header{
+							SequenceNumber: 3,
+						},
+					},
+				},
+				{
+					ts: now,
+					content: incomingRTCP{
+						pkts: []rtcp.Packet{
+							&rtcp.SenderReport{
+								SSRC:    0,
+								NTPTime: ntp.ToNTP(now),
+								Reports: []rtcp.ReceptionReport{
+									{
+										SSRC:               0,
+										FractionLost:       85,
+										TotalLost:          1,
+										LastSequenceNumber: 3,
+										Jitter:             45000,
+									},
+								},
+							},
+							cname,
+						},
+					},
+				},
+			},
+			expectedOutboundRTPStreamStats: OutboundRTPStreamStats{
+				SentRTPStreamStats: SentRTPStreamStats{
+					PacketsSent: 2,
+					BytesSent:   24,
+				},
+				HeaderBytesSent: 24,
+			},
+			expectedRemoteInboundRTPStreamStats: RemoteInboundRTPStreamStats{
+				ReceivedRTPStreamStats: ReceivedRTPStreamStats{
+					PacketsReceived: 2,
+					PacketsLost:     1,
+					Jitter:          0.5,
+				},
+				FractionLost: 0.33203125,
+			},
+			expectedRemoteOutboundRTPStreamStats: RemoteOutboundRTPStreamStats{
+				RemoteTimeStamp: ntp.ToTime(ntp.ToNTP(now)),
+				ReportsSent:     1,
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("%v:%v", i, cc.name), func(t *testing.T) {
 			recorder := newRecorder(0, 90_000, logging.NewDefaultLoggerFactory())


### PR DESCRIPTION
#### Description
Fix for reading reception reports blocks from Sender Reports.

#### Reference issue
Fixes #412 
