### PR TITLE
Remove factor 8 from pacing burst size

### DIFF
--- a/pkg/pacing/interceptor.go
+++ b/pkg/pacing/interceptor.go
@@ -182,7 +182,7 @@ func burst(rate int, interval time.Duration) int {
 	}
 	f := float64(time.Second.Milliseconds() / interval.Milliseconds())
 
-	return 8 * int(float64(rate)/f)
+	return max(8*1500, int(float64(rate)/f))
 }
 
 // setRate updates the pacing rate and burst of the rate limiter.

--- a/pkg/pacing/interceptor_test.go
+++ b/pkg/pacing/interceptor_test.go
@@ -70,7 +70,7 @@ func TestInterceptor(t *testing.T) {
 
 		i.SetRate("", 1_000_000)
 		assert.Equal(t, 1_000_000, mp.rate)
-		assert.Equal(t, 40_000, mp.burst)
+		assert.Equal(t, 12000, mp.burst)
 	})
 
 	t.Run("paces_packets", func(t *testing.T) {


### PR DESCRIPTION
#### Description

Removes the factor 8 from pacing bursts because burst size is already calculated in bits, not bytes. Instead, I added a min burst size to allow at least one packet to be sent.

#### Reference issue
Fixes #408 
