### PR TITLE
GCC: Keep increase path monotonic

### DIFF
--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -149,7 +149,12 @@ func (c *rateController) increase(now time.Time) int {
 		increase := int(math.Max(1000.0, alpha*expectedPacketSizeBits))
 		c.lastUpdate = now
 
-		return int(math.Min(float64(c.target+increase), 1.5*float64(c.latestReceivedRate)))
+		rate := int(math.Min(float64(c.target+increase), 1.5*float64(c.latestReceivedRate)))
+		if rate < c.target {
+			return c.target
+		}
+
+		return rate
 	}
 	eta := math.Pow(1.08, math.Min(float64(now.Sub(c.lastUpdate).Milliseconds())/1000, 1.0))
 	c.lastUpdate = now

--- a/pkg/gcc/rate_controller_test.go
+++ b/pkg/gcc/rate_controller_test.go
@@ -76,3 +76,16 @@ func TestRateControllerRun(t *testing.T) {
 		})
 	}
 }
+
+func TestRateControllerIncreaseDoesNotReduceTarget(t *testing.T) {
+	now := time.Now()
+	for _, target := range []int{1_000_000, 8_000_000} {
+		controller := newRateController(time.Now, target, 100_000, 50_000_000, func(DelayStats) {})
+		controller.latestReceivedRate = 1_350_000
+		controller.latestDecreaseRate.update(1_300_000)
+		controller.latestDecreaseRate.update(1_350_000)
+		controller.lastUpdate = now.Add(-100 * time.Millisecond)
+
+		assert.GreaterOrEqual(t, controller.increase(now), target)
+	}
+}


### PR DESCRIPTION
The steady-state increase branch caps its result at 1.5 times the received rate. When that cap is below the current target, the increase operation can unexpectedly reduce the target even though the controller remains in the increase state. The other increase branch already guards this invariant.

Keep the target unchanged when the computed rate would be lower, and cover the regression with a focused test.

Validated with go test ./... and go test -race ./pkg/gcc.