### PR TITLE
Fix additive increase step at packet boundaries

### DIFF
--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -14,6 +14,10 @@ const (
 	beta             = 0.85
 )
 
+// maxPacketSizeBits bounds the expected packet size used by the additive
+// increase. Chosen as a conservative MTU-limited RTP payload.
+const maxPacketSizeBits = 1200 * 8
+
 type rateController struct {
 	now                  now
 	initialTargetBitrate int
@@ -141,8 +145,12 @@ func (c *rateController) increase(now time.Time) int {
 		float64(c.latestReceivedRate) > c.latestDecreaseRate.average-3*c.latestDecreaseRate.stdDeviation &&
 		float64(c.latestReceivedRate) < c.latestDecreaseRate.average+3*c.latestDecreaseRate.stdDeviation {
 		bitsPerFrame := float64(c.target) / 30.0
-		packetsPerFrame := math.Ceil(bitsPerFrame / (1200 * 8))
-		expectedPacketSizeBits := bitsPerFrame / packetsPerFrame
+		// A packet carries at most one MTU, and a frame smaller than that is sent
+		// in a single packet. Dividing by ceil(bitsPerFrame/MTU) instead yields the
+		// mean packet size, which falls discontinuously whenever the packet count
+		// increments: at 30 fps a target rising from 288 to 290 kbps halves it, so
+		// the additive step can shrink while the target grows.
+		expectedPacketSizeBits := math.Min(bitsPerFrame, maxPacketSizeBits)
 
 		responseTime := 100*time.Millisecond + c.latestRTT
 		alpha := 0.5 * math.Min(float64(now.Sub(c.lastUpdate).Milliseconds())/float64(responseTime.Milliseconds()), 1.0)

--- a/pkg/gcc/rate_controller_additive_increase_test.go
+++ b/pkg/gcc/rate_controller_additive_increase_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package gcc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The additive increase derives its step from the expected packet size. Deriving
+// that size as bitsPerFrame/ceil(bitsPerFrame/MTU) gives the mean packet size,
+// which falls discontinuously whenever the packet count increments, so a higher
+// target can be raised in smaller steps than a lower one. A packet is at most one
+// MTU, so above one MTU per frame the step should simply be constant.
+func TestRateControllerAdditiveIncreaseStepIsMonotonicInTarget(t *testing.T) {
+	// At 30 fps with a 1200-byte MTU, 288 kbps is exactly one packet per frame and
+	// 290 kbps spills into a second; 576 and 580 kbps straddle the next boundary.
+	// alpha is 0.5 below, so the step is half the expected packet size in bits.
+	for _, tc := range []struct {
+		target   int
+		wantStep int
+	}{
+		{240_000, 4_000}, // under one MTU per frame: half of 8000 bits
+		{288_000, 4_800}, // exactly one MTU per frame
+		{290_000, 4_800}, // second packet begins; step must not fall
+		{300_000, 4_800},
+		{480_000, 4_800},
+		{576_000, 4_800},
+		{580_000, 4_800}, // third packet begins
+		{600_000, 4_800},
+	} {
+		c := newRateController(
+			func() time.Time { return time.Time{} },
+			tc.target, 1_000, 50_000_000, func(DelayStats) {},
+		)
+		// Select the near-a-previous-decrease regime that uses the additive branch.
+		// The received rate must sit inside average +/- 3*stdDeviation.
+		c.latestDecreaseRate.average = float64(tc.target)
+		c.latestDecreaseRate.stdDeviation = float64(tc.target) * 0.05
+		c.latestReceivedRate = tc.target
+		c.latestRTT = 50 * time.Millisecond
+
+		// responseTime is 100ms+RTT, so a 150ms gap gives alpha = 0.5.
+		got := c.increase(time.Time{}.Add(150 * time.Millisecond))
+
+		assert.Equal(t, tc.target+tc.wantStep, got,
+			"target %d: additive step was %d, want %d", tc.target, got-tc.target, tc.wantStep)
+	}
+}


### PR DESCRIPTION
The additive increase is documented as raising the estimate by "at most half a packet per response_time". It doesn't, because of how the packet size is derived.

A packet holds at most 1200 bytes, or 9600 bits. The code derives the size by averaging a frame over the packets it needs:

```go
bitsPerFrame := float64(c.target) / 30.0
packetsPerFrame := math.Ceil(bitsPerFrame / (1200 * 8))
expectedPacketSizeBits := bitsPerFrame / packetsPerFrame
```

At a 288 kbps target a frame is exactly 9600 bits, so it fits one packet and the step is half of a full packet:

```
frame 9600 bits  ->  [9600]         average 9600  ->  step 4800
```

At 290 kbps the frame is 9667 bits. That is 67 bits too big for one packet, so it takes two: one full, one nearly empty.

```
frame 9667 bits  ->  [9600][67]     average 4833  ->  step 2416
```

The target rose by 0.7% and the step halved. Averaging a full packet together with a nearly empty trailing one answers "what is the mean fill of this frame's packets", not "how big is a packet". It recurs at every packet boundary:

| target | frame | packets | step | fraction of a packet |
|---|---|---|---|---|
| 288 kbps | 9600 | `[9600]` | 4800 | 0.50 |
| 290 kbps | 9667 | `[9600][67]` | 2416 | **0.25** |
| 580 kbps | 19333 | `[9600][9600][133]` | 3222 | **0.34** |
| 1.5 Mbps | 50000 | six packets | 4166 | 0.43 |

So the estimate grows by a quarter of a packet where the text says half, and the controller ramps most slowly exactly while climbing through a boundary.

The fix: a packet holds at most one MTU, and a frame smaller than that travels in a single packet.

```go
expectedPacketSizeBits := math.Min(bitsPerFrame, maxPacketSizeBits)
```

Every row above becomes 0.50. Targets below one MTU per frame are unchanged — 240 kbps still steps 4000 — so the "slightly slower slope for the additive increase at lower bitrates" is preserved. Only the boundary jumps go away. The inlined `1200 * 8` becomes a named constant.

On provenance, since the three replaced lines will look familiar: they are from [draft-ietf-rmcat-gcc-02 section 5.5](https://datatracker.ietf.org/doc/html/draft-ietf-rmcat-gcc-02#section-5.5). That section introduces them with "it **can for instance** be computed", and it names the input to the increase `expected_packet_size_bits` while the example computes `avg_packet_size_bits`. The normative statement is the "at most half a packet" sentence, and this change is what makes it true.

The added test asserts the exact step across the boundaries above. On `main` it fails with `target 290000: additive step was 2416, want 4800`. `go test ./...` is green across the repo.
