### PR TITLE
Remove fallback because peer will only send TWCC

### DIFF
--- a/pkg/rtpfb/interceptor.go
+++ b/pkg/rtpfb/interceptor.go
@@ -110,6 +110,8 @@ type Interceptor struct {
 }
 
 func (i *Interceptor) bindTWCCStream(twccHdrExtID uint8, writer interceptor.RTPWriter) interceptor.RTPWriter {
+	loggedMissingExt := false
+
 	return interceptor.RTPWriterFunc(func(
 		header *rtp.Header,
 		payload []byte,
@@ -119,12 +121,14 @@ func (i *Interceptor) bindTWCCStream(twccHdrExtID uint8, writer interceptor.RTPW
 
 		var twccHdrExt rtp.TransportCCExtension
 		if err := twccHdrExt.Unmarshal(header.GetExtension(twccHdrExtID)); err != nil {
-			i.log.Warnf(
-				"CCFB configured for TWCC, but failed to get TWCC header extension from outgoing packet."+
-					"Falling back to saving history for CCFB feedback reports. err: %v",
-				err,
-			)
-			i.history.addOutgoing(header.SSRC, header.SequenceNumber, false, 0, header.MarshalSize()+len(payload), ts)
+			if !loggedMissingExt {
+				i.log.Warnf(
+					"CCFB configured for TWCC, but failed to get TWCC header extension from outgoing packet."+
+						"Packets without the extension cannot be tracked and will not appear in feedback reports. err: %v",
+					err,
+				)
+				loggedMissingExt = true
+			}
 
 			return writer.Write(header, payload, attributes)
 		}


### PR DESCRIPTION
The peer negotiated TWCC so this is what is will send us. Falling back to sequence numbers doesn't help here because we won't be able to match the numbers to the incoming TWCC reports. We only push items to the history that will never be used.

Also reduce the logging by logging the warning once instead of repeating it for every packet.
