### PR TITLE
Add one MTU headroom to pacing burst

### DIFF
--- a/pkg/pacing/interceptor.go
+++ b/pkg/pacing/interceptor.go
@@ -178,15 +178,17 @@ type Interceptor struct {
 	onClose func(string)
 }
 
-// burst calculates the minimal burst size required to reach the given rate and
-// pacing interval. The burst is never smaller than minBurst, so that a packet
-// of minBurst bits can always be sent.
+// burst calculates the burst size required to reach the given rate at the
+// given pacing interval. It is one interval's worth of tokens plus minBurst
+// bits of headroom, so that a packet of minBurst bits can always be sent and
+// the tokens left over after a tick are carried into the next one instead of
+// being clamped away.
 func burst(rate int, interval time.Duration, minBurst int) int {
 	if interval <= 0 {
 		interval = time.Millisecond
 	}
 
-	return max(minBurst, int(float64(rate)*interval.Seconds()))
+	return minBurst + int(float64(rate)*interval.Seconds())
 }
 
 // setRate updates the pacing rate and burst of the rate limiter.

--- a/pkg/pacing/interceptor_test.go
+++ b/pkg/pacing/interceptor_test.go
@@ -66,17 +66,17 @@ func TestBurst(t *testing.T) {
 		minBurst int
 		expected int
 	}{
-		{"sub_millisecond_interval", 1_000_000, 500 * time.Microsecond, minBurst, minBurst},
-		{"sub_millisecond_interval_high_rate", 100_000_000, 500 * time.Microsecond, minBurst, 50_000},
-		{"zero_interval_defaults_to_1ms", 100_000_000, 0, minBurst, 100_000},
-		{"negative_interval_defaults_to_1ms", 100_000_000, -time.Second, minBurst, 100_000},
-		{"rate_below_min_burst", 300_000, 5 * time.Millisecond, minBurst, minBurst},
-		{"divides_evenly", 3_000_000, 5 * time.Millisecond, minBurst, 15_000},
-		{"does_not_divide_evenly", 3_000_000, 7 * time.Millisecond, minBurst, 21_000},
-		{"long_interval", 3_000_000, 33 * time.Millisecond, minBurst, 99_000},
+		{"sub_millisecond_interval", 1_000_000, 500 * time.Microsecond, minBurst, minBurst + 500},
+		{"sub_millisecond_interval_high_rate", 100_000_000, 500 * time.Microsecond, minBurst, minBurst + 50_000},
+		{"zero_interval_defaults_to_1ms", 100_000_000, 0, minBurst, minBurst + 100_000},
+		{"negative_interval_defaults_to_1ms", 100_000_000, -time.Second, minBurst, minBurst + 100_000},
+		{"low_rate", 300_000, 5 * time.Millisecond, minBurst, minBurst + 1_500},
+		{"divides_evenly", 3_000_000, 5 * time.Millisecond, minBurst, minBurst + 15_000},
+		{"does_not_divide_evenly", 3_000_000, 7 * time.Millisecond, minBurst, minBurst + 21_000},
+		{"long_interval", 3_000_000, 33 * time.Millisecond, minBurst, minBurst + 99_000},
 		{"zero_rate", 0, 5 * time.Millisecond, minBurst, minBurst},
-		{"grown_min_burst_wins", 300_000, 5 * time.Millisecond, 8 * 4000, 8 * 4000},
-		{"rate_above_grown_min_burst", 100_000_000, 5 * time.Millisecond, 8 * 4000, 500_000},
+		{"grown_min_burst", 300_000, 5 * time.Millisecond, 8 * 4000, 8*4000 + 1_500},
+		{"grown_min_burst_high_rate", 100_000_000, 5 * time.Millisecond, 8 * 4000, 8*4000 + 500_000},
 	} {
 		t.Run(cc.name, func(t *testing.T) {
 			assert.Equal(t, cc.expected, burst(cc.rate, cc.interval, cc.minBurst))
@@ -99,7 +99,7 @@ func TestInterceptor(t *testing.T) {
 
 		i.SetRate("", 1_000_000)
 		assert.Equal(t, 1_000_000, mp.rate)
-		assert.Equal(t, 12000, mp.burst)
+		assert.Equal(t, 12000+5000, mp.burst)
 	})
 
 	t.Run("grows_burst", func(t *testing.T) {
@@ -128,14 +128,14 @@ func TestInterceptor(t *testing.T) {
 		pacer.growMTU(4000)
 		mp.lock.Lock()
 		assert.Equal(t, 300_000, mp.rate)
-		assert.Equal(t, 8*4000, mp.burst)
+		assert.Equal(t, 8*4000+1_500, mp.burst)
 		mp.lock.Unlock()
 
 		pacer.growMTU(1500)
 		factory.SetRate("id", 600_000)
 		mp.lock.Lock()
 		assert.Equal(t, 600_000, mp.rate)
-		assert.Equal(t, 8*4000, mp.burst)
+		assert.Equal(t, 8*4000+3_000, mp.burst)
 		mp.lock.Unlock()
 	})
 


### PR DESCRIPTION
This adds one MTU of headroom to the pacing burst. Without it, the burst will be clamped every interval. That is a problem when the pacer has left over tokens but not enough for a complete packet. The leftover tokens should be usable in the next interval, but they're clamped by the max burst, so we drop them instead of using them on the next packet.